### PR TITLE
Project renaming fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ In order to use this library, you need to have an account on <http://pusher.com>
 
 ## Installation
 
-The pusher-rest-java library is available in Maven Central:
+The pusher-http-java library is available in Maven Central:
 
 ```
 <dependency>
   <groupId>com.pusher</groupId>
-  <artifactId>pusher-rest-java</artifactId>
+  <artifactId>pusher-http-java</artifactId>
   <version>0.9.0</version>
 </dependency>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -8,10 +8,10 @@
   </parent>
 
   <groupId>com.pusher</groupId>
-  <artifactId>pusher-rest-java</artifactId>
+  <artifactId>pusher-http-java</artifactId>
   <name>Pusher REST Client</name>
   <version>0.9.1-SNAPSHOT</version>
-  <url>http://github.com/pusher/pusher-rest-java</url>
+  <url>http://github.com/pusher/pusher-http-java</url>
 
   <description>
     This is a Java library for interacting with Pusher.com's REST API
@@ -24,15 +24,15 @@
   </properties>
 
   <scm>
-    <url>scm:git:git@github.com:pusher/pusher-rest-java</url>
-    <connection>scm:git:git@github.com:pusher/pusher-rest-java</connection>
-    <developerConnection>scm:git:git@github.com:pusher/pusher-rest-java</developerConnection>
+    <url>scm:git:git@github.com:pusher/pusher-http-java</url>
+    <connection>scm:git:git@github.com:pusher/pusher-http-java</connection>
+    <developerConnection>scm:git:git@github.com:pusher/pusher-http-java</developerConnection>
   </scm>
 
   <licenses>
     <license>
       <name>MIT</name>
-      <url>https://raw.github.com/pusher/pusher-rest-java/master/LICENCE.txt</url>
+      <url>https://raw.github.com/pusher/pusher-http-java/master/LICENCE.txt</url>
     </license>
   </licenses>
 
@@ -114,7 +114,7 @@
         <version>0.8</version>
         <configuration>
           <server>github</server>
-          <repositoryName>pusher-rest-java</repositoryName> <!-- github repo name -->
+          <repositoryName>pusher-http-java</repositoryName> <!-- github repo name -->
           <repositoryOwner>pusher</repositoryOwner> <!-- github username -->
           <noJekyll>true</noJekyll> <!-- disable webpage processing -->
         </configuration>

--- a/src/main/java/com/pusher/rest/Pusher.java
+++ b/src/main/java/com/pusher/rest/Pusher.java
@@ -35,7 +35,7 @@ import com.pusher.rest.util.Prerequisites;
 /**
  * A library for interacting with the Pusher REST API.
  * <p>
- * See http://github.com/pusher/pusher-rest-java for an overview
+ * See http://github.com/pusher/pusher-http-java for an overview
  * <p>
  * Essentially:
  * <pre>


### PR DESCRIPTION
Note: we decided to keep the `com.pusher.rest` namespace to avoid breaking back-compat