### PR TITLE
Fix test for customSerialisationByExtension

### DIFF
--- a/src/test/java/com/pusher/rest/PusherTest.java
+++ b/src/test/java/com/pusher/rest/PusherTest.java
@@ -99,9 +99,15 @@ public class PusherTest {
                 return (String)data;
             }
         };
+        p.configureHttpClient(new HttpClientBuilder() {
+            @Override
+            public CloseableHttpClient build() {
+                return httpClient;
+            }
+        });
 
         context.checking(new Expectations() {{
-            oneOf(httpClient).execute(with(field("data", "this is my strong data")));
+            oneOf(httpClient).execute(with(field("data", "this is my string data")));
         }});
 
         p.trigger("my-channel", "event", "this is my string data");


### PR DESCRIPTION
This test isn't being applied because the httpClient isn't set properly in the target Pusher instance. Once the test is fixed it fails because of a typo in the assertion. This commit fixes both issues.
