### PR TITLE
Prefer association over inheritance when setting a custom serialiser

### DIFF
--- a/src/main/java/com/pusher/rest/GsonPayloadSerialiser.java
+++ b/src/main/java/com/pusher/rest/GsonPayloadSerialiser.java
@@ -1,0 +1,23 @@
+package com.pusher.rest;
+
+import com.google.gson.Gson;
+
+/**
+ * Serialises the payload of a notification using Gson.
+ */
+class GsonPayloadSerialiser implements PayloadSerialiser {
+	private final Gson gson;
+	
+	GsonPayloadSerialiser(Gson gson) {
+		this.gson = gson;
+	}
+
+	/**
+     * @param data an unserialised event payload
+     * @return a serialised event payload
+     */
+	@Override
+	public String serialise(Object o) {
+		return gson.toJson(o);
+	}
+}

--- a/src/main/java/com/pusher/rest/PayloadSerialiser.java
+++ b/src/main/java/com/pusher/rest/PayloadSerialiser.java
@@ -1,0 +1,8 @@
+package com.pusher.rest;
+
+/**
+ * Serialises the payload of a notification.
+ */
+public interface PayloadSerialiser {
+	String serialise(Object o);
+}

--- a/src/test/java/com/pusher/rest/PusherTest.java
+++ b/src/test/java/com/pusher/rest/PusherTest.java
@@ -8,6 +8,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -106,6 +107,22 @@ public class PusherTest {
 
         p.trigger("my-channel", "event", "this is my string data");
     }
+    
+    @Test
+	public void customSerialisationByAssociation() throws Exception {
+		p.setPayloadSerialiser(new PayloadSerialiser() {
+			@Override
+			public String serialise(Object o) {
+				return ((String)o).toUpperCase(Locale.ROOT);
+			}
+		});
+		
+	    context.checking(new Expectations() {{
+            oneOf(httpClient).execute(with(field("data", "THIS IS MY STRING DATA")));
+        }});
+
+        p.trigger("my-channel", "event", "this is my string data");
+	}
 
     @Test
     public void batchEvents() throws IOException {


### PR DESCRIPTION
Currently the `Pusher` javadoc recommends overriding the `serialise` method  to do custom serialisation of the notification body. I end up doing this whenever I use Pusher, as Gson is too limited for most serious applications. At work I've ended up writing a subclass that accepts a functional interface for the payload serialiser. Having this baked into Pusher would make life a lot easier for developers who want to integrate it with their existing serialisation setup.
