### PR TITLE
Ensuring all HTTP connections are closed

### DIFF
--- a/src/main/java/com/pusher/rest/Pusher.java
+++ b/src/main/java/com/pusher/rest/Pusher.java
@@ -15,6 +15,7 @@ import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.client.utils.HttpClientUtils;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.DefaultConnectionReuseStrategy;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -447,8 +448,10 @@ public class Pusher {
                 .build();
         request.setConfig(config);
 
+        HttpResponse response = null;
+
         try {
-            final HttpResponse response = client.execute(request);
+            response = client.execute(request);
 
             final ByteArrayOutputStream baos = new ByteArrayOutputStream();
             response.getEntity().writeTo(baos);
@@ -458,6 +461,9 @@ public class Pusher {
         }
         catch (final IOException e) {
             return Result.fromException(e);
+        } finally {
+            // Ensure the response is fully closed
+            HttpClientUtils.closeQuietly(response);
         }
     }
 


### PR DESCRIPTION
Hello! I believe there are some network edge conditions that result in Pusher leaking connections.

This commit adds the HttpClient best practice:

>  "_to ensure correct deallocation of system resources the user MUST call CloseableHttpResponse#close() from a finally clause_"

 (https://hc.apache.org/httpcomponents-client-ga/quickstart.html)

This is a tricky issue (eg. it also affects the Twilio Java client). Let me know if you have any questions! And we appreciate the work you do on this library :)