### PR TITLE
Move to junit5 + hamcrest matchers to address reflection warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 ---
 language: java
 jdk:
-  - oraclejdk8
-  - openjdk7
+  - openjdk8
+  - openjdk9
+  - openjdk10
+  - openjdk11

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ Status](https://travis-ci.org/pusher/pusher-http-java.svg?branch=master)](https:
 
 In order to use this library, you need to have an account on <http://pusher.com>. After registering, you will need the application credentials for your app.
 
+## Supported platforms
+ - Java 8+ - Tested with 8, 9, 10 and 11.
+
 ## Installation
 
 The pusher-http-java library is available in Maven Central:

--- a/pom.xml
+++ b/pom.xml
@@ -21,8 +21,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <!-- github server corresponds to entry in ~/.m2/settings.xml -->
     <github.global.server>github</github.global.server>
-    <maven.compiler.source>6</maven.compiler.source>
-    <maven.compiler.target>6</maven.compiler.target>
+    <maven.compiler.source>8</maven.compiler.source>
+    <maven.compiler.target>8</maven.compiler.target>
   </properties>
 
   <scm>
@@ -212,14 +212,8 @@
     </dependency>
     <dependency>
       <groupId>org.jmock</groupId>
-      <artifactId>jmock-junit4</artifactId>
-      <version>2.6.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jmock</groupId>
-      <artifactId>jmock-legacy</artifactId>
-      <version>2.6.0</version>
+      <artifactId>jmock-junit5</artifactId>
+      <version>2.12.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/test/java/com/pusher/rest/PusherChannelAuthTest.java
+++ b/src/test/java/com/pusher/rest/PusherChannelAuthTest.java
@@ -1,11 +1,13 @@
 package com.pusher.rest;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+
 
 import java.util.Collections;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import com.pusher.rest.data.PresenceUser;
 
@@ -25,64 +27,89 @@ public class PusherChannelAuthTest {
                 is("{\"auth\":\"278d425bdf160c739803:208cbbce2a22fd7d7c3509046b17a97b99d345cf4c195bc0d54af9004a022b0b\"}"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void privateChannelWrongPrefix() {
-        p.authenticate("1234.1234", "presence-foobar");
+
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            p.authenticate("1234.1234", "presence-foobar");
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void privateChannelNoPrefix() {
-        p.authenticate("1234.1234", "foobar");
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            p.authenticate("1234.1234", "foobar");
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void trailingColonSocketId() {
-        p.authenticate("1.1:", "private-foobar");
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            p.authenticate("1.1:", "private-foobar");
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void trailingNLSocketId() {
-        p.authenticate("1.1\n", "private-foobar");
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            p.authenticate("1.1\n", "private-foobar");
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void leadingColonSocketId() {
-        p.authenticate(":1.1", "private-foobar");
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            p.authenticate(":1.1", "private-foobar");
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void leadingColonNLSocketId() {
-        p.authenticate(":\n1.1", "private-foobar");
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            p.authenticate(":\n1.1", "private-foobar");
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void trailingColonNLSocketId() {
-        p.authenticate("1.1\n:", "private-foobar");
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            p.authenticate("1.1\n:", "private-foobar");
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void trailingColonChannel() {
-        p.authenticate("1.1", "private-foobar:");
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            p.authenticate("1.1", "private-foobar:");
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void leadingColonChannel() {
-        p.authenticate("1.1", ":private-foobar");
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            p.authenticate("1.1", ":private-foobar");
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void leadingColonNLChannel() {
-        p.authenticate("1.1", ":\nprivate-foobar");
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            p.authenticate("1.1", ":\nprivate-foobar");
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void trailingColonNLChannel() {
-        p.authenticate("1.1", "private-foobar\n:");
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            p.authenticate("1.1", "private-foobar\n:");
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void trailingNLChannel() {
-        p.authenticate("1.1", "private-foobar\n");
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            p.authenticate("1.1", "private-foobar\n");
+        });
     }
 
     @Test
@@ -91,13 +118,17 @@ public class PusherChannelAuthTest {
                 is("{\"auth\":\"278d425bdf160c739803:afaed3695da2ffd16931f457e338e6c9f2921fa133ce7dac49f529792be6304c\",\"channel_data\":\"{\\\"user_id\\\":10,\\\"user_info\\\":{\\\"name\\\":\\\"Mr. Pusher\\\"}}\"}"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void presenceChannelWrongPrefix() {
-        p.authenticate("1234.1234", "private-foobar", new PresenceUser("dave"));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            p.authenticate("1234.1234", "private-foobar", new PresenceUser("dave"));
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void presenceChannelNoPrefix() {
-        p.authenticate("1234.1234", "foobar", new PresenceUser("dave"));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            p.authenticate("1234.1234", "foobar", new PresenceUser("dave"));
+        });
     }
 }

--- a/src/test/java/com/pusher/rest/PusherHttpTest.java
+++ b/src/test/java/com/pusher/rest/PusherHttpTest.java
@@ -1,7 +1,7 @@
 package com.pusher.rest;
 
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 
@@ -13,9 +13,9 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.localserver.LocalTestServer;
 import org.apache.http.protocol.HttpContext;
 import org.apache.http.protocol.HttpRequestHandler;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.pusher.rest.data.Result;
 import com.pusher.rest.data.Result.Status;
@@ -33,7 +33,7 @@ public class PusherHttpTest {
 
     private Pusher p;
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         server = new LocalTestServer(null, null);
         server.register("/*", new HttpRequestHandler() {
@@ -51,7 +51,7 @@ public class PusherHttpTest {
         p = new Pusher(PusherTest.APP_ID, PusherTest.KEY, PusherTest.SECRET);
     }
 
-    @After
+    @AfterEach
     public void teardown() throws Exception {
         server.stop();
     }

--- a/src/test/java/com/pusher/rest/PusherTest.java
+++ b/src/test/java/com/pusher/rest/PusherTest.java
@@ -14,10 +14,11 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
-import org.jmock.integration.junit4.JUnit4Mockery;
-import org.jmock.lib.legacy.ClassImposteriser;
-import org.junit.Before;
-import org.junit.Test;
+import org.jmock.junit5.JUnit5Mockery;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
@@ -35,15 +36,15 @@ public class PusherTest {
     static final String KEY    = "157a2f3df564323a4a73";
     static final String SECRET = "3457a88be87f890dcd98";
 
-    private final Mockery context = new JUnit4Mockery() {{
-        setImposteriser(ClassImposteriser.INSTANCE);
+    private final Mockery context = new JUnit5Mockery() {{
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
     }};
 
     private CloseableHttpClient httpClient = context.mock(CloseableHttpClient.class);
 
     private final Pusher p = new Pusher(APP_ID, KEY, SECRET);
 
-    @Before
+    @BeforeEach
     public void setup() {
         p.configureHttpClient(new HttpClientBuilder() {
             @Override
@@ -195,11 +196,13 @@ public class PusherTest {
         p.trigger(channels, "event", Collections.singletonMap("name", "value"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void channelListLimitOverLimit() {
-        final List<String> channels = Arrays.asList(new String[] { "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten", "eleven" });
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            final List<String> channels = Arrays.asList(new String[] { "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten", "eleven" });
+            p.trigger(channels, "event", Collections.singletonMap("name", "value"));
+        });
 
-        p.trigger(channels, "event", Collections.singletonMap("name", "value"));
     }
 
     @Test
@@ -221,8 +224,10 @@ public class PusherTest {
         p.get("/channels");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void reservedParameter() {
-        p.get("/channels", Collections.singletonMap("auth_timestamp", "anything"));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            p.get("/channels", Collections.singletonMap("auth_timestamp", "anything"));
+        });
     }
 }

--- a/src/test/java/com/pusher/rest/PusherTestUrlConfig.java
+++ b/src/test/java/com/pusher/rest/PusherTestUrlConfig.java
@@ -1,11 +1,12 @@
 package com.pusher.rest;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.lang.reflect.Field;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class PusherTestUrlConfig {
 
@@ -31,27 +32,34 @@ public class PusherTestUrlConfig {
         assertField(p, "appId", "00001");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testUrlMissingField() throws Exception {
-        new Pusher("https://key@api.example.com:4433/apps/appId");
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            new Pusher("https://key@api.example.com:4433/apps/appId");
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testUrlEmptySecret() throws Exception {
-        new Pusher("https://key:@api.example.com:4433/apps/appId");
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            new Pusher("https://key:@api.example.com:4433/apps/appId");
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testUrlEmptyKey() throws Exception {
-        new Pusher("https://:secret@api.example.com:4433/apps/appId");
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            new Pusher("https://:secret@api.example.com:4433/apps/appId");
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testUrlInvalidScheme() throws Exception {
-        new Pusher("telnet://key:secret@api.example.com:4433/apps/appId");
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            new Pusher("telnet://key:secret@api.example.com:4433/apps/appId");
+        });
     }
 
-    @SuppressWarnings("unchecked")
     private static <V> void assertField(final Object o, final String fieldName, final V expected) throws Exception {
         final Field field = o.getClass().getDeclaredField(fieldName);
         field.setAccessible(true);

--- a/src/test/java/com/pusher/rest/SignatureUtilTest.java
+++ b/src/test/java/com/pusher/rest/SignatureUtilTest.java
@@ -1,14 +1,14 @@
 package com.pusher.rest;
 
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SignatureUtilTest {
 


### PR DESCRIPTION
Compiling with anything more modern than Java 7 threw a warning about Illegal reflection to do with junit4s use of a code generation library called CGLIB. I upgraded a few dependencies and fixed the tests.