### PR TITLE
Allow a trigger to 100 channels

### DIFF
--- a/src/main/java/com/pusher/rest/Pusher.java
+++ b/src/main/java/com/pusher/rest/Pusher.java
@@ -357,7 +357,7 @@ public class Pusher {
         Prerequisites.nonNull("channels", channels);
         Prerequisites.nonNull("eventName", eventName);
         Prerequisites.nonNull("data", data);
-        Prerequisites.maxLength("channels", 10, channels);
+        Prerequisites.maxLength("channels", 100, channels);
         Prerequisites.noNullMembers("channels", channels);
         Prerequisites.areValidChannels(channels);
         Prerequisites.isValidSocketId(socketId);


### PR DESCRIPTION
This is the correct value as specified in the HTTP API reference
docs: https://pusher.com/docs/channels/library_auth_reference/rest-api#request

Resolves: https://github.com/pusher/pusher-http-java/issues/23

(I'm not sure we should have the SDK performing this kind of validation, but that's a different problem).