### PR TITLE
Allowing non-blocking HTTP calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,15 @@ The pusher-http-java library is available in Maven Central:
 
 Javadocs for the latest version are published at <http://pusher.github.io/pusher-http-java/>. Javadoc artifacts are also in Maven and should be available for automatic download and attaching by your IDE.
 
+## Synchronous vs asynchronous
+
+The pusher-http-java library provides two APIs:
+
+- `com.pusher.rest.Pusher`, synchronous, based on Apache HTTP Client (4 series)
+- `com.pusher.rest.PusherAsync`, asynchronous, based on [AsyncHttpClient (AHC)](https://github.com/AsyncHttpClient/async-http-client)
+
+The following examples are using `Pusher`, but `PusherAsync` exposes the exact same API, while returning `CompletableFuture<T>` instead of `T`.
+
 ## Configuration
 
 The minimum configuration required to use the `Pusher` object are the three constructor arguments which identify your Pusher app. You can find them by going to "API Keys" on your app at <https://dashboard.pusher.com>.
@@ -71,25 +80,19 @@ If you wish to set a non-standard endpoint, perhaps for testing, you may use `se
 pusher.setHost("api-eu.pusher.com");
 ```
 
-#### Timeouts
-
-The default timeout is 4 seconds. A timeout in milliseconds to be applied to socket opens and reads can be applied, for example 10 seconds:
-
-```java
-pusher.setRequestTimeout(10000);
-```
-
 #### SSL
 
 HTTPS can be used as transport by calling `setEncrypted(true)`. Note that your credentials are not exposed on an unencrypted connection, however the contents of your messages are. Use this option if your messages themselves are sensitive.
 
 #### Advanced HTTP configuration
 
-The library uses Apache HTTP Client (4 series) internally to make HTTP requests. In order to expose some of the rich and fine configuration available in this component, it is partially exposed. The HttpClient uses the Builder pattern to specify configuration. The Pusher Channels library exposes a method to fetch an `HttpClientBuilder` with sensible defaults, and a method to set the client instance in use to one created by a particular builder. By using these two methods, you can further configure the client, overriding defaults or adding new settings.
+##### Synchronous library
+
+The synchronous library uses Apache HTTP Client (4 series) internally to make HTTP requests. In order to expose some of the rich and fine configuration available in this component, it is partially exposed. The HttpClient uses the Builder pattern to specify configuration. The Pusher Channels library exposes a method to fetch an `HttpClientBuilder` with sensible defaults, and a method to set the client instance in use to one created by a particular builder. By using these two methods, you can further configure the client, overriding defaults or adding new settings.
 
 For example:
 
-##### HTTP Proxy
+###### HTTP Proxy
 
 To set a proxy:
 
@@ -97,6 +100,22 @@ To set a proxy:
 HttpClientBuilder builder = Pusher.defaultHttpClientBuilder();
 builder.setProxy(new HttpHost("proxy.example.com"));
 pusher.configureHttpClient(builder);
+```
+
+##### Asynchronous library
+
+The asynchronous library uses AsyncHttpClient (AHC) internally to make HTTP requests. Just like the synchronous library, you have a fine-grained control over the HTTP configuration, see https://github.com/AsyncHttpClient/async-http-client. For example:
+
+###### HTTP Proxy
+
+To set a proxy:
+
+```java
+pusherAsync.configureHttpClient(
+    config()
+        .setProxyServer(proxyServer("127.0.0.1", 38080))
+        .setMaxRequestRetry(5)
+);
 ```
 
 ## Usage
@@ -238,7 +257,7 @@ Query parameters can't contain following keys, as they are used to sign the requ
 - auth_signature
 - body_md5
 
-### Multi-threaded usage
+### Multi-threaded usage with the synchronous library
 
 The library is threadsafe and intended for use from many threads simultaneously. By default, HTTP connections are persistent and a pool of open connections is maintained. This re-use reduces the overhead involved in repeated TCP connection establishments and teardowns.
 

--- a/pom.xml
+++ b/pom.xml
@@ -192,6 +192,11 @@
       <version>4.3.6</version>
     </dependency>
     <dependency>
+      <groupId>org.asynchttpclient</groupId>
+      <artifactId>async-http-client</artifactId>
+      <version>2.10.4</version>
+    </dependency>
+    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
       <version>2.2.4</version>

--- a/src/main/java/com/pusher/rest/Pusher.java
+++ b/src/main/java/com/pusher/rest/Pusher.java
@@ -1,15 +1,6 @@
 package com.pusher.rest;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.net.URI;
-import java.util.Collections;
-import java.util.List;
-import java.util.ArrayList;
-import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
+import com.pusher.rest.data.Result;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpGet;
@@ -22,20 +13,11 @@ import org.apache.http.impl.client.DefaultConnectionKeepAliveStrategy;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 
-import com.google.gson.FieldNamingPolicy;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-
-import com.pusher.rest.data.AuthData;
-import com.pusher.rest.data.Event;
-import com.pusher.rest.data.EventBatch;
-import com.pusher.rest.data.PresenceUser;
-import com.pusher.rest.data.Result;
-import com.pusher.rest.data.TriggerData;
-import com.pusher.rest.data.Validity;
-import com.pusher.rest.marshaller.DataMarshaller;
-import com.pusher.rest.marshaller.DefaultDataMarshaller;
-import com.pusher.rest.util.Prerequisites;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Collections;
+import java.util.Map;
 
 /**
  * A library for interacting with the Pusher HTTP API.
@@ -65,23 +47,11 @@ import com.pusher.rest.util.Prerequisites;
  * }
  * </pre>
  */
-public class Pusher {
-    private static final Gson BODY_SERIALISER = new GsonBuilder()
-            .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
-            .create();
+public class Pusher extends PusherAbstract<Result> {
 
-    private static final Pattern HEROKU_URL = Pattern.compile("(https?)://(.+):(.+)@(.+:?.*)/apps/(.+)");
-
-    private final String appId;
-    private final String key;
-    private final String secret;
-
-    private String host = "api.pusherapp.com";
-    private String scheme = "http";
     private int requestTimeout = 4000; // milliseconds
 
     private CloseableHttpClient client;
-    private DataMarshaller dataMarshaller;
 
     /**
      * Construct an instance of the Pusher object through which you may interact with the Pusher API.
@@ -93,86 +63,18 @@ public class Pusher {
      * @param secret The App Secret. Used to sign requests to the API, this should be treated as sensitive and not distributed.
      */
     public Pusher(final String appId, final String key, final String secret) {
-        Prerequisites.nonEmpty("appId", appId);
-        Prerequisites.nonEmpty("key", key);
-        Prerequisites.nonEmpty("secret", secret);
-        Prerequisites.isValidSha256Key("secret", secret);
-
-        this.appId = appId;
-        this.key = key;
-        this.secret = secret;
-
-        configure();
+        super(appId, key, secret);
+        configureHttpClient(defaultHttpClientBuilder());
     }
 
     public Pusher(final String url) {
-        Prerequisites.nonNull("url", url);
-
-        final Matcher m = HEROKU_URL.matcher(url);
-        if (m.matches()) {
-            this.scheme = m.group(1);
-            this.key = m.group(2);
-            this.secret = m.group(3);
-            this.host = m.group(4);
-            this.appId = m.group(5);
-        }
-        else {
-            throw new IllegalArgumentException("URL '" + url + "' does not match pattern '<scheme>://<key>:<secret>@<host>[:<port>]/apps/<appId>'");
-        }
-
-        Prerequisites.isValidSha256Key("secret", secret);
-        configure();
-    }
-
-    private void configure() {
+        super(url);
         configureHttpClient(defaultHttpClientBuilder());
-        this.dataMarshaller = new DefaultDataMarshaller();
     }
 
     /*
      * CONFIG
      */
-
-    /**
-     * For testing or specifying an alternative cluster. See also {@link #setCluster(String)} for the latter.
-     * <p>
-     * Default: api.pusherapp.com
-     *
-     * @param host the API endpoint host
-     */
-    public void setHost(final String host) {
-        Prerequisites.nonNull("host", host);
-
-        this.host = host;
-    }
-
-    /**
-     * For Specifying an alternative cluster.
-     * <p>
-     * See also {@link #setHost(String)} for targetting an arbitrary endpoint.
-     *
-     * @param cluster the Pusher cluster to target
-     */
-    public void setCluster(final String cluster) {
-        Prerequisites.nonNull("cluster", cluster);
-
-        this.host = "api-" + cluster + ".pusher.com";
-    }
-
-    /**
-     * Set whether to use a secure connection to the API (SSL).
-     * <p>
-     * Authentication is secure even without this option, requests cannot be faked or replayed with access
-     * to their plain text, a secure connection is only required if the requests or responses contain
-     * sensitive information.
-     * <p>
-     * Default: false
-     *
-     * @param encrypted whether to use SSL to contact the API
-     */
-    public void setEncrypted(final boolean encrypted) {
-        this.scheme = encrypted ? "https" : "http";
-    }
 
     /**
      * Default: 4000
@@ -181,40 +83,6 @@ public class Pusher {
      */
     public void setRequestTimeout(final int requestTimeout) {
         this.requestTimeout = requestTimeout;
-    }
-
-    /**
-     * Set the Gson instance used to marshal Objects passed to {@link #trigger(List, String, Object)}
-     * Set the marshaller used to serialize Objects passed to {@link #trigger(List, String, Object)}
-     * and friends.
-     * By default, the library marshals the objects provided to JSON using the Gson library
-     * (see https://code.google.com/p/google-gson/ for more details). By providing an instance
-     * here, you may exert control over the marshalling, for example choosing how Java property
-     * names are mapped on to the field names in the JSON representation, allowing you to match
-     * the expected scheme on the client side.
-     * We added the {@link #setDataMarshaller(DataMarshaller)} method to allow specification
-     * of other marshalling libraries. This method was kept around to maintain backwards
-     * compatibility.
-     * @param gson a GSON instance configured to your liking
-     */
-    public void setGsonSerialiser(final Gson gson) {
-        setDataMarshaller(new DefaultDataMarshaller(gson));
-    }
-
-    /**
-     * Set a custom marshaller used to serialize Objects passed to {@link #trigger(List, String, Object)}
-     * and friends.
-     * <p>
-     * By default, the library marshals the objects provided to JSON using the Gson library
-     * (see https://code.google.com/p/google-gson/ for more details). By providing an instance
-     * here, you may exert control over the marshalling, for example choosing how Java property
-     * names are mapped on to the field names in the JSON representation, allowing you to match
-     * the expected scheme on the client side.
-     *
-     * @param marshaller a DataMarshaller instance configured to your liking
-     */
-    public void setDataMarshaller(final DataMarshaller marshaller) {
-        this.dataMarshaller = marshaller;
     }
 
     /**
@@ -274,156 +142,11 @@ public class Pusher {
         this.client = builder.build();
     }
 
-    /**
-     * This method provides an override point if the default Gson based serialisation is absolutely
-     * unsuitable for your use case, even with customisation of the Gson instance doing the serialisation.
-     * <p>
-     * For example, in the simplest case, you might already have your data pre-serialised and simply want
-     * to elide the default serialisation:
-     * <pre>
-     * Pusher pusher = new Pusher(appId, key, secret) {
-     *     protected String serialise(final Object data) {
-     *         return (String)data;
-     *     }
-     * };
-     *
-     * pusher.trigger("my-channel", "my-event", "{\"my-data\":\"my-value\"}");
-     * </pre>
-     *
-     * @param data an unserialised event payload
-     * @return a serialised event payload
-     */
-    protected String serialise(final Object data) {
-        return dataMarshaller.marshal(data);
-    }
-
     /*
      * REST
      */
 
-    /**
-     * Publish a message to a single channel.
-     * <p>
-     * The message data should be a POJO, which will be serialised to JSON for submission.
-     * Use {@link #setDataMarshaller(DataMarshaller)} to control the serialisation
-     * <p>
-     * Note that if you do not wish to create classes specifically for the purpose of specifying
-     * the message payload, use Map&lt;String, Object&gt;. These maps will nest just fine.
-     *
-     * @param channel the channel name on which to trigger the event
-     * @param eventName the name given to the event
-     * @param data an object which will be serialised to create the event body
-     * @return a {@link Result} object encapsulating the success state and response to the request
-     */
-    public Result trigger(final String channel, final String eventName, final Object data) {
-        return trigger(channel, eventName, data, null);
-    }
-
-    /**
-     * Publish identical messages to multiple channels.
-     *
-     * @param channels the channel names on which to trigger the event
-     * @param eventName the name given to the event
-     * @param data an object which will be serialised to create the event body
-     * @return a {@link Result} object encapsulating the success state and response to the request
-     */
-    public Result trigger(final List<String> channels, final String eventName, final Object data) {
-        return trigger(channels, eventName, data, null);
-    }
-
-    /**
-     * Publish a message to a single channel, excluding the specified socketId from receiving the message.
-     *
-     * @param channel the channel name on which to trigger the event
-     * @param eventName the name given to the event
-     * @param data an object which will be serialised to create the event body
-     * @param socketId a socket id which should be excluded from receiving the event
-     * @return a {@link Result} object encapsulating the success state and response to the request
-     */
-    public Result trigger(final String channel, final String eventName, final Object data, final String socketId) {
-        return trigger(Collections.singletonList(channel), eventName, data, socketId);
-    }
-
-    /**
-     * Publish identical messages to multiple channels, excluding the specified socketId from receiving the message.
-     *
-     * @param channels the channel names on which to trigger the event
-     * @param eventName the name given to the event
-     * @param data an object which will be serialised to create the event body
-     * @param socketId a socket id which should be excluded from receiving the event
-     * @return a {@link Result} object encapsulating the success state and response to the request
-     */
-    public Result trigger(final List<String> channels, final String eventName, final Object data, final String socketId) {
-        Prerequisites.nonNull("channels", channels);
-        Prerequisites.nonNull("eventName", eventName);
-        Prerequisites.nonNull("data", data);
-        Prerequisites.maxLength("channels", 100, channels);
-        Prerequisites.noNullMembers("channels", channels);
-        Prerequisites.areValidChannels(channels);
-        Prerequisites.isValidSocketId(socketId);
-
-        final String body = BODY_SERIALISER.toJson(new TriggerData(channels, eventName, serialise(data), socketId));
-
-        return post("/events", body);
-    }
-
-    /**
-     * Publish a batch of different events with a single API call.
-     *
-     * The batch is limited to 10 events on our multi-tenant clusters.
-     *
-     * @param batch a list of events to publish
-     * @return a {@link Result} object encapsulating the success state and response to the request
-     */
-    public Result trigger(final List<Event> batch) {
-        final List<Event> eventsWithSerialisedBodies = new ArrayList<Event>(batch.size());
-        for (final Event e : batch) {
-            eventsWithSerialisedBodies.add(
-                new Event(
-                    e.getChannel(),
-                    e.getName(),
-                    serialise(e.getData()),
-                    e.getSocketId()
-                )
-            );
-        }
-        final String body = BODY_SERIALISER.toJson(new EventBatch(eventsWithSerialisedBodies));
-
-        return post("/batch_events", body);
-    }
-
-    /**
-     * Make a generic HTTP call to the Pusher API.
-     * <p>
-     * See: http://pusher.com/docs/rest_api
-     * <p>
-     * NOTE: the path specified here is relative to that of your app. For example, to access
-     * the channel list for your app, simply pass "/channels". Do not include the "/apps/[appId]"
-     * at the beginning of the path.
-     *
-     * @param path the path (e.g. /channels) to query
-     * @return a {@link Result} object encapsulating the success state and response to the request
-     */
-    public Result get(final String path) {
-        return get(path, Collections.<String, String>emptyMap());
-    }
-
-    /**
-     * Make a generic HTTP call to the Pusher API.
-     * <p>
-     * See: http://pusher.com/docs/rest_api
-     * <p>
-     * Parameters should be a map of query parameters for the HTTP call, and may be null
-     * if none are required.
-     * <p>
-     * NOTE: the path specified here is relative to that of your app. For example, to access
-     * the channel list for your app, simply pass "/channels". Do not include the "/apps/[appId]"
-     * at the beginning of the path.
-     *
-     * @param path the path (e.g. /channels) to query
-     * @param parameters query parameters to submit with the request
-     * @return a {@link Result} object encapsulating the success state and response to the request
-     */
+    @Override
     public Result get(final String path, final Map<String, String> parameters) {
         final String fullPath = "/apps/" + appId + path;
         final URI uri = SignatureUtil.uri("GET", scheme, host, fullPath, null, key, secret, parameters);
@@ -431,21 +154,7 @@ public class Pusher {
         return httpCall(new HttpGet(uri));
     }
 
-    /**
-     * Make a generic HTTP call to the Pusher API.
-     * <p>
-     * The body should be a UTF-8 encoded String
-     * <p>
-     * See: http://pusher.com/docs/rest_api
-     * <p>
-     * NOTE: the path specified here is relative to that of your app. For example, to access
-     * the channel list for your app, simply pass "/channels". Do not include the "/apps/[appId]"
-     * at the beginning of the path.
-     *
-     * @param path the path (e.g. /channels) to submit
-     * @param body the body to submit
-     * @return a {@link Result} object encapsulating the success state and response to the request
-     */
+    @Override
     public Result post(final String path, final String body) {
         final String fullPath = "/apps/" + appId + path;
         final URI uri = SignatureUtil.uri("POST", scheme, host, fullPath, body, key, secret, Collections.<String, String>emptyMap());
@@ -479,115 +188,5 @@ public class Pusher {
         catch (final IOException e) {
             return Result.fromException(e);
         }
-    }
-
-    /**
-     * If you wanted to send the HTTP API requests manually (e.g. using a different HTTP client), this method
-     * will return a java.net.URI which includes all of the appropriate query parameters which sign the request.
-     *
-     * @param method the HTTP method, e.g. GET, POST
-     * @param path the HTTP path, e.g. /channels
-     * @param body the HTTP request body, if there is one (otherwise pass null)
-     * @return a URI object which includes the necessary query params for request authentication
-     */
-    public URI signedUri(final String method, final String path, final String body) {
-        return signedUri(method, path, body, Collections.<String, String>emptyMap());
-    }
-
-    /**
-     * If you wanted to send the HTTP API requests manually (e.g. using a different HTTP client), this method
-     * will return a java.net.URI which includes all of the appropriate query parameters which sign the request.
-     * <p>
-     * Note that any further query parameters you wish to be add must be specified here, as they form part of the signature.
-     *
-     * @param method the HTTP method, e.g. GET, POST
-     * @param path the HTTP path, e.g. /channels
-     * @param body the HTTP request body, if there is one (otherwise pass null)
-     * @param parameters HTTP query parameters to be included in the request
-     * @return a URI object which includes the necessary query params for request authentication
-     */
-    public URI signedUri(final String method, final String path, final String body, final Map<String, String> parameters) {
-        return SignatureUtil.uri(method, scheme, host, path, body, key, secret, parameters);
-    }
-
-    /*
-     * CHANNEL AUTHENTICATION
-     */
-
-    /**
-     * Generate authentication response to authorise a user on a private channel
-     * <p>
-     * The return value is the complete body which should be returned to a client requesting authorisation.
-     *
-     * @param socketId the socket id of the connection to authenticate
-     * @param channel the name of the channel which the socket id should be authorised to join
-     * @return an authentication string, suitable for return to the requesting client
-     */
-    public String authenticate(final String socketId, final String channel) {
-        Prerequisites.nonNull("socketId", socketId);
-        Prerequisites.nonNull("channel", channel);
-        Prerequisites.isValidChannel(channel);
-        Prerequisites.isValidSocketId(socketId);
-
-        if (channel.startsWith("presence-")) {
-            throw new IllegalArgumentException("This method is for private channels, use authenticate(String, String, PresenceUser) to authenticate for a presence channel.");
-        }
-        if (!channel.startsWith("private-")) {
-            throw new IllegalArgumentException("Authentication is only applicable to private and presence channels");
-        }
-
-        final String signature = SignatureUtil.sign(socketId + ":" + channel, secret);
-        return BODY_SERIALISER.toJson(new AuthData(key, signature));
-    }
-
-    /**
-     * Generate authentication response to authorise a user on a presence channel
-     * <p>
-     * The return value is the complete body which should be returned to a client requesting authorisation.
-     *
-     * @param socketId the socket id of the connection to authenticate
-     * @param channel the name of the channel which the socket id should be authorised to join
-     * @param user a {@link PresenceUser} object which represents the channel data to be associated with the user
-     * @return an authentication string, suitable for return to the requesting client
-     */
-    public String authenticate(final String socketId, final String channel, final PresenceUser user) {
-        Prerequisites.nonNull("socketId", socketId);
-        Prerequisites.nonNull("channel", channel);
-        Prerequisites.nonNull("user", user);
-        Prerequisites.isValidChannel(channel);
-        Prerequisites.isValidSocketId(socketId);
-
-        if (channel.startsWith("private-")) {
-            throw new IllegalArgumentException("This method is for presence channels, use authenticate(String, String) to authenticate for a private channel.");
-        }
-        if (!channel.startsWith("presence-")) {
-            throw new IllegalArgumentException("Authentication is only applicable to private and presence channels");
-        }
-
-        final String channelData = BODY_SERIALISER.toJson(user);
-        final String signature = SignatureUtil.sign(socketId + ":" + channel + ":" + channelData, secret);
-        return BODY_SERIALISER.toJson(new AuthData(key, signature, channelData));
-    }
-
-    /*
-     * WEBHOOK VALIDATION
-     */
-
-    /**
-     * Check the signature on a webhook received from Pusher
-     *
-     * @param xPusherKeyHeader the X-Pusher-Key header as received in the webhook request
-     * @param xPusherSignatureHeader the X-Pusher-Signature header as received in the webhook request
-     * @param body the webhook body
-     * @return enum representing the possible validities of the webhook request
-     */
-    public Validity validateWebhookSignature(final String xPusherKeyHeader, final String xPusherSignatureHeader, final String body) {
-        if (!xPusherKeyHeader.trim().equals(key)) {
-            // We can't validate the signature, because it was signed with a different key to the one we were initialised with.
-            return Validity.SIGNED_WITH_WRONG_KEY;
-        }
-
-        final String recalculatedSignature = SignatureUtil.sign(body, secret);
-        return xPusherSignatureHeader.trim().equals(recalculatedSignature) ? Validity.VALID : Validity.INVALID;
     }
 }

--- a/src/main/java/com/pusher/rest/Pusher.java
+++ b/src/main/java/com/pusher/rest/Pusher.java
@@ -46,6 +46,8 @@ import java.util.Map;
  *   // etc
  * }
  * </pre>
+ *
+ * See {@link PusherAsync} for the asynchronous implementation.
  */
 public class Pusher extends PusherAbstract<Result> {
 

--- a/src/main/java/com/pusher/rest/Pusher.java
+++ b/src/main/java/com/pusher/rest/Pusher.java
@@ -47,7 +47,7 @@ import java.net.URI;
  *
  * See {@link PusherAsync} for the asynchronous implementation.
  */
-public class Pusher extends PusherAbstract<Result> {
+public class Pusher extends PusherAbstract<Result> implements AutoCloseable {
 
     private int requestTimeout = 4000; // milliseconds
 
@@ -133,9 +133,8 @@ public class Pusher extends PusherAbstract<Result> {
      */
     public void configureHttpClient(final HttpClientBuilder builder) {
         try {
-            if (client != null) client.close();
-        }
-        catch (IOException e) {
+            close();
+        } catch (final Exception e) {
             // Not a lot useful we can do here
         }
 
@@ -147,12 +146,12 @@ public class Pusher extends PusherAbstract<Result> {
      */
 
     @Override
-    protected Result doGet(URI uri) {
+    protected Result doGet(final URI uri) {
         return httpCall(new HttpGet(uri));
     }
 
     @Override
-    protected Result doPost(URI uri, String body) {
+    protected Result doPost(final URI uri, final String body) {
         final StringEntity bodyEntity = new StringEntity(body, "UTF-8");
         bodyEntity.setContentType("application/json");
 
@@ -183,4 +182,12 @@ public class Pusher extends PusherAbstract<Result> {
             return Result.fromException(e);
         }
     }
+
+    @Override
+    public void close() throws Exception {
+        if (client != null) {
+            client.close();
+        }
+    }
+
 }

--- a/src/main/java/com/pusher/rest/Pusher.java
+++ b/src/main/java/com/pusher/rest/Pusher.java
@@ -16,8 +16,6 @@ import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.URI;
-import java.util.Collections;
-import java.util.Map;
 
 /**
  * A library for interacting with the Pusher HTTP API.
@@ -149,18 +147,12 @@ public class Pusher extends PusherAbstract<Result> {
      */
 
     @Override
-    public Result get(final String path, final Map<String, String> parameters) {
-        final String fullPath = "/apps/" + appId + path;
-        final URI uri = SignatureUtil.uri("GET", scheme, host, fullPath, null, key, secret, parameters);
-
+    protected Result doGet(URI uri) {
         return httpCall(new HttpGet(uri));
     }
 
     @Override
-    public Result post(final String path, final String body) {
-        final String fullPath = "/apps/" + appId + path;
-        final URI uri = SignatureUtil.uri("POST", scheme, host, fullPath, body, key, secret, Collections.<String, String>emptyMap());
-
+    protected Result doPost(URI uri, String body) {
         final StringEntity bodyEntity = new StringEntity(body, "UTF-8");
         bodyEntity.setContentType("application/json");
 

--- a/src/main/java/com/pusher/rest/PusherAbstract.java
+++ b/src/main/java/com/pusher/rest/PusherAbstract.java
@@ -1,0 +1,444 @@
+package com.pusher.rest;
+
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.pusher.rest.data.AuthData;
+import com.pusher.rest.data.Event;
+import com.pusher.rest.data.EventBatch;
+import com.pusher.rest.data.PresenceUser;
+import com.pusher.rest.data.Result;
+import com.pusher.rest.data.TriggerData;
+import com.pusher.rest.data.Validity;
+import com.pusher.rest.marshaller.DataMarshaller;
+import com.pusher.rest.marshaller.DefaultDataMarshaller;
+import com.pusher.rest.util.Prerequisites;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+abstract class PusherAbstract<T> {
+    protected static final Gson BODY_SERIALISER = new GsonBuilder()
+            .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+            .create();
+
+    private static final Pattern HEROKU_URL = Pattern.compile("(https?)://(.+):(.+)@(.+:?.*)/apps/(.+)");
+
+    protected final String appId;
+    protected final String key;
+    protected final String secret;
+
+    protected String host = "api.pusherapp.com";
+    protected String scheme = "http";
+
+    private DataMarshaller dataMarshaller;
+
+    /**
+     * Construct an instance of the Pusher object through which you may interact with the Pusher API.
+     * <p>
+     * The parameters to use are found on your dashboard at https://app.pusher.com and are specific per App.
+     * <p>
+     *
+     * @param appId  The ID of the App you will to interact with.
+     * @param key    The App Key, the same key you give to websocket clients to identify your app when they connect to Pusher.
+     * @param secret The App Secret. Used to sign requests to the API, this should be treated as sensitive and not distributed.
+     */
+    public PusherAbstract(final String appId, final String key, final String secret) {
+        Prerequisites.nonEmpty("appId", appId);
+        Prerequisites.nonEmpty("key", key);
+        Prerequisites.nonEmpty("secret", secret);
+        Prerequisites.isValidSha256Key("secret", secret);
+
+        this.appId = appId;
+        this.key = key;
+        this.secret = secret;
+
+        configureDataMarshaller();
+    }
+
+    public PusherAbstract(final String url) {
+        Prerequisites.nonNull("url", url);
+
+        final Matcher m = HEROKU_URL.matcher(url);
+        if (m.matches()) {
+            this.scheme = m.group(1);
+            this.key = m.group(2);
+            this.secret = m.group(3);
+            this.host = m.group(4);
+            this.appId = m.group(5);
+        } else {
+            throw new IllegalArgumentException("URL '" + url + "' does not match pattern '<scheme>://<key>:<secret>@<host>[:<port>]/apps/<appId>'");
+        }
+
+        Prerequisites.isValidSha256Key("secret", secret);
+        configureDataMarshaller();
+    }
+
+    private void configureDataMarshaller() {
+        this.dataMarshaller = new DefaultDataMarshaller();
+    }
+
+    /*
+     * CONFIG
+     */
+
+    /**
+     * For testing or specifying an alternative cluster. See also {@link #setCluster(String)} for the latter.
+     * <p>
+     * Default: api.pusherapp.com
+     *
+     * @param host the API endpoint host
+     */
+    public void setHost(final String host) {
+        Prerequisites.nonNull("host", host);
+
+        this.host = host;
+    }
+
+    /**
+     * For Specifying an alternative cluster.
+     * <p>
+     * See also {@link #setHost(String)} for targetting an arbitrary endpoint.
+     *
+     * @param cluster the Pusher cluster to target
+     */
+    public void setCluster(final String cluster) {
+        Prerequisites.nonNull("cluster", cluster);
+
+        this.host = "api-" + cluster + ".pusher.com";
+    }
+
+    /**
+     * Set whether to use a secure connection to the API (SSL).
+     * <p>
+     * Authentication is secure even without this option, requests cannot be faked or replayed with access
+     * to their plain text, a secure connection is only required if the requests or responses contain
+     * sensitive information.
+     * <p>
+     * Default: false
+     *
+     * @param encrypted whether to use SSL to contact the API
+     */
+    public void setEncrypted(final boolean encrypted) {
+        this.scheme = encrypted ? "https" : "http";
+    }
+
+    /**
+     * Set the Gson instance used to marshal Objects passed to {@link #trigger(List, String, Object)}
+     * Set the marshaller used to serialize Objects passed to {@link #trigger(List, String, Object)}
+     * and friends.
+     * By default, the library marshals the objects provided to JSON using the Gson library
+     * (see https://code.google.com/p/google-gson/ for more details). By providing an instance
+     * here, you may exert control over the marshalling, for example choosing how Java property
+     * names are mapped on to the field names in the JSON representation, allowing you to match
+     * the expected scheme on the client side.
+     * We added the {@link #setDataMarshaller(DataMarshaller)} method to allow specification
+     * of other marshalling libraries. This method was kept around to maintain backwards
+     * compatibility.
+     * @param gson a GSON instance configured to your liking
+     */
+    public void setGsonSerialiser(final Gson gson) {
+        setDataMarshaller(new DefaultDataMarshaller(gson));
+    }
+
+    /**
+     * Set a custom marshaller used to serialize Objects passed to {@link #trigger(List, String, Object)}
+     * and friends.
+     * <p>
+     * By default, the library marshals the objects provided to JSON using the Gson library
+     * (see https://code.google.com/p/google-gson/ for more details). By providing an instance
+     * here, you may exert control over the marshalling, for example choosing how Java property
+     * names are mapped on to the field names in the JSON representation, allowing you to match
+     * the expected scheme on the client side.
+     *
+     * @param marshaller a DataMarshaller instance configured to your liking
+     */
+    public void setDataMarshaller(final DataMarshaller marshaller) {
+        this.dataMarshaller = marshaller;
+    }
+
+    /**
+     * This method provides an override point if the default Gson based serialisation is absolutely
+     * unsuitable for your use case, even with customisation of the Gson instance doing the serialisation.
+     * <p>
+     * For example, in the simplest case, you might already have your data pre-serialised and simply want
+     * to elide the default serialisation:
+     * <pre>
+     * Pusher pusher = new Pusher(appId, key, secret) {
+     *     protected String serialise(final Object data) {
+     *         return (String)data;
+     *     }
+     * };
+     *
+     * pusher.trigger("my-channel", "my-event", "{\"my-data\":\"my-value\"}");
+     * </pre>
+     *
+     * @param data an unserialised event payload
+     * @return a serialised event payload
+     */
+    protected String serialise(final Object data) {
+        return dataMarshaller.marshal(data);
+    }
+
+    /*
+     * REST
+     */
+
+    /**
+     * Publish a message to a single channel.
+     * <p>
+     * The message data should be a POJO, which will be serialised to JSON for submission.
+     * Use {@link #setDataMarshaller(DataMarshaller)} to control the serialisation
+     * <p>
+     * Note that if you do not wish to create classes specifically for the purpose of specifying
+     * the message payload, use Map&lt;String, Object&gt;. These maps will nest just fine.
+     *
+     * @param channel   the channel name on which to trigger the event
+     * @param eventName the name given to the event
+     * @param data      an object which will be serialised to create the event body
+     * @return a {@link Result} object encapsulating the success state and response to the request
+     */
+    public T trigger(final String channel, final String eventName, final Object data) {
+        return trigger(channel, eventName, data, null);
+    }
+
+    /**
+     * Publish identical messages to multiple channels.
+     *
+     * @param channels  the channel names on which to trigger the event
+     * @param eventName the name given to the event
+     * @param data      an object which will be serialised to create the event body
+     * @return a {@link Result} object encapsulating the success state and response to the request
+     */
+    public T trigger(final List<String> channels, final String eventName, final Object data) {
+        return trigger(channels, eventName, data, null);
+    }
+
+    /**
+     * Publish a message to a single channel, excluding the specified socketId from receiving the message.
+     *
+     * @param channel   the channel name on which to trigger the event
+     * @param eventName the name given to the event
+     * @param data      an object which will be serialised to create the event body
+     * @param socketId  a socket id which should be excluded from receiving the event
+     * @return a {@link Result} object encapsulating the success state and response to the request
+     */
+    public T trigger(final String channel, final String eventName, final Object data, final String socketId) {
+        return trigger(Collections.singletonList(channel), eventName, data, socketId);
+    }
+
+    /**
+     * Publish identical messages to multiple channels, excluding the specified socketId from receiving the message.
+     *
+     * @param channels  the channel names on which to trigger the event
+     * @param eventName the name given to the event
+     * @param data      an object which will be serialised to create the event body
+     * @param socketId  a socket id which should be excluded from receiving the event
+     * @return a {@link Result} object encapsulating the success state and response to the request
+     */
+    public T trigger(final List<String> channels, final String eventName, final Object data, final String socketId) {
+        Prerequisites.nonNull("channels", channels);
+        Prerequisites.nonNull("eventName", eventName);
+        Prerequisites.nonNull("data", data);
+        Prerequisites.maxLength("channels", 100, channels);
+        Prerequisites.noNullMembers("channels", channels);
+        Prerequisites.areValidChannels(channels);
+        Prerequisites.isValidSocketId(socketId);
+
+        final String body = BODY_SERIALISER.toJson(new TriggerData(channels, eventName, serialise(data), socketId));
+
+        return post("/events", body);
+    }
+
+    /**
+     * Publish a batch of different events with a single API call.
+     * <p>
+     * The batch is limited to 10 events on our multi-tenant clusters.
+     *
+     * @param batch a list of events to publish
+     * @return a {@link Result} object encapsulating the success state and response to the request
+     */
+    public T trigger(final List<Event> batch) {
+        final List<Event> eventsWithSerialisedBodies = new ArrayList<Event>(batch.size());
+        for (final Event e : batch) {
+            eventsWithSerialisedBodies.add(
+                    new Event(
+                            e.getChannel(),
+                            e.getName(),
+                            serialise(e.getData()),
+                            e.getSocketId()
+                    )
+            );
+        }
+        final String body = BODY_SERIALISER.toJson(new EventBatch(eventsWithSerialisedBodies));
+
+        return post("/batch_events", body);
+    }
+
+    /**
+     * Make a generic HTTP call to the Pusher API.
+     * <p>
+     * See: http://pusher.com/docs/rest_api
+     * <p>
+     * NOTE: the path specified here is relative to that of your app. For example, to access
+     * the channel list for your app, simply pass "/channels". Do not include the "/apps/[appId]"
+     * at the beginning of the path.
+     *
+     * @param path the path (e.g. /channels) to query
+     * @return a {@link Result} object encapsulating the success state and response to the request
+     */
+    public T get(final String path) {
+        return get(path, Collections.<String, String>emptyMap());
+    }
+
+    /**
+     * Make a generic HTTP call to the Pusher API.
+     * <p>
+     * See: http://pusher.com/docs/rest_api
+     * <p>
+     * Parameters should be a map of query parameters for the HTTP call, and may be null
+     * if none are required.
+     * <p>
+     * NOTE: the path specified here is relative to that of your app. For example, to access
+     * the channel list for your app, simply pass "/channels". Do not include the "/apps/[appId]"
+     * at the beginning of the path.
+     *
+     * @param path       the path (e.g. /channels) to query
+     * @param parameters query parameters to submit with the request
+     * @return a {@link Result} object encapsulating the success state and response to the request
+     */
+    public abstract T get(final String path, final Map<String, String> parameters);
+
+    /**
+     * Make a generic HTTP call to the Pusher API.
+     * <p>
+     * The body should be a UTF-8 encoded String
+     * <p>
+     * See: http://pusher.com/docs/rest_api
+     * <p>
+     * NOTE: the path specified here is relative to that of your app. For example, to access
+     * the channel list for your app, simply pass "/channels". Do not include the "/apps/[appId]"
+     * at the beginning of the path.
+     *
+     * @param path the path (e.g. /channels) to submit
+     * @param body the body to submit
+     * @return a {@link Result} object encapsulating the success state and response to the request
+     */
+    public abstract T post(final String path, final String body);
+
+    /**
+     * If you wanted to send the HTTP API requests manually (e.g. using a different HTTP client), this method
+     * will return a java.net.URI which includes all of the appropriate query parameters which sign the request.
+     *
+     * @param method the HTTP method, e.g. GET, POST
+     * @param path   the HTTP path, e.g. /channels
+     * @param body   the HTTP request body, if there is one (otherwise pass null)
+     * @return a URI object which includes the necessary query params for request authentication
+     */
+    public URI signedUri(final String method, final String path, final String body) {
+        return signedUri(method, path, body, Collections.<String, String>emptyMap());
+    }
+
+    /**
+     * If you wanted to send the HTTP API requests manually (e.g. using a different HTTP client), this method
+     * will return a java.net.URI which includes all of the appropriate query parameters which sign the request.
+     * <p>
+     * Note that any further query parameters you wish to be add must be specified here, as they form part of the signature.
+     *
+     * @param method     the HTTP method, e.g. GET, POST
+     * @param path       the HTTP path, e.g. /channels
+     * @param body       the HTTP request body, if there is one (otherwise pass null)
+     * @param parameters HTTP query parameters to be included in the request
+     * @return a URI object which includes the necessary query params for request authentication
+     */
+    public URI signedUri(final String method, final String path, final String body, final Map<String, String> parameters) {
+        return SignatureUtil.uri(method, scheme, host, path, body, key, secret, parameters);
+    }
+
+    /*
+     * CHANNEL AUTHENTICATION
+     */
+
+    /**
+     * Generate authentication response to authorise a user on a private channel
+     * <p>
+     * The return value is the complete body which should be returned to a client requesting authorisation.
+     *
+     * @param socketId the socket id of the connection to authenticate
+     * @param channel  the name of the channel which the socket id should be authorised to join
+     * @return an authentication string, suitable for return to the requesting client
+     */
+    public String authenticate(final String socketId, final String channel) {
+        Prerequisites.nonNull("socketId", socketId);
+        Prerequisites.nonNull("channel", channel);
+        Prerequisites.isValidChannel(channel);
+        Prerequisites.isValidSocketId(socketId);
+
+        if (channel.startsWith("presence-")) {
+            throw new IllegalArgumentException("This method is for private channels, use authenticate(String, String, PresenceUser) to authenticate for a presence channel.");
+        }
+        if (!channel.startsWith("private-")) {
+            throw new IllegalArgumentException("Authentication is only applicable to private and presence channels");
+        }
+
+        final String signature = SignatureUtil.sign(socketId + ":" + channel, secret);
+        return BODY_SERIALISER.toJson(new AuthData(key, signature));
+    }
+
+    /**
+     * Generate authentication response to authorise a user on a presence channel
+     * <p>
+     * The return value is the complete body which should be returned to a client requesting authorisation.
+     *
+     * @param socketId the socket id of the connection to authenticate
+     * @param channel  the name of the channel which the socket id should be authorised to join
+     * @param user     a {@link PresenceUser} object which represents the channel data to be associated with the user
+     * @return an authentication string, suitable for return to the requesting client
+     */
+    public String authenticate(final String socketId, final String channel, final PresenceUser user) {
+        Prerequisites.nonNull("socketId", socketId);
+        Prerequisites.nonNull("channel", channel);
+        Prerequisites.nonNull("user", user);
+        Prerequisites.isValidChannel(channel);
+        Prerequisites.isValidSocketId(socketId);
+
+        if (channel.startsWith("private-")) {
+            throw new IllegalArgumentException("This method is for presence channels, use authenticate(String, String) to authenticate for a private channel.");
+        }
+        if (!channel.startsWith("presence-")) {
+            throw new IllegalArgumentException("Authentication is only applicable to private and presence channels");
+        }
+
+        final String channelData = BODY_SERIALISER.toJson(user);
+        final String signature = SignatureUtil.sign(socketId + ":" + channel + ":" + channelData, secret);
+        return BODY_SERIALISER.toJson(new AuthData(key, signature, channelData));
+    }
+
+    /*
+     * WEBHOOK VALIDATION
+     */
+
+    /**
+     * Check the signature on a webhook received from Pusher
+     *
+     * @param xPusherKeyHeader       the X-Pusher-Key header as received in the webhook request
+     * @param xPusherSignatureHeader the X-Pusher-Signature header as received in the webhook request
+     * @param body                   the webhook body
+     * @return enum representing the possible validities of the webhook request
+     */
+    public Validity validateWebhookSignature(final String xPusherKeyHeader, final String xPusherSignatureHeader, final String body) {
+        if (!xPusherKeyHeader.trim().equals(key)) {
+            // We can't validate the signature, because it was signed with a different key to the one we were initialised with.
+            return Validity.SIGNED_WITH_WRONG_KEY;
+        }
+
+        final String recalculatedSignature = SignatureUtil.sign(body, secret);
+        return xPusherSignatureHeader.trim().equals(recalculatedSignature) ? Validity.VALID : Validity.INVALID;
+    }
+
+}

--- a/src/main/java/com/pusher/rest/PusherAbstract.java
+++ b/src/main/java/com/pusher/rest/PusherAbstract.java
@@ -319,7 +319,14 @@ public abstract class PusherAbstract<T> {
      * @param parameters query parameters to submit with the request
      * @return a {@link Result} object encapsulating the success state and response to the request
      */
-    public abstract T get(final String path, final Map<String, String> parameters);
+    public T get(final String path, final Map<String, String> parameters) {
+        final String fullPath = "/apps/" + appId + path;
+        final URI uri = SignatureUtil.uri("GET", scheme, host, fullPath, null, key, secret, parameters);
+
+        return doGet(uri);
+    }
+
+    protected abstract T doGet(final URI uri);
 
     /**
      * Make a generic HTTP call to the Pusher API.
@@ -336,7 +343,14 @@ public abstract class PusherAbstract<T> {
      * @param body the body to submit
      * @return a {@link Result} object encapsulating the success state and response to the request
      */
-    public abstract T post(final String path, final String body);
+    public T post(final String path, final String body) {
+        final String fullPath = "/apps/" + appId + path;
+        final URI uri = SignatureUtil.uri("POST", scheme, host, fullPath, body, key, secret, Collections.<String, String>emptyMap());
+
+        return doPost(uri, body);
+    }
+
+    protected abstract T doPost(final URI uri, final String body);
 
     /**
      * If you wanted to send the HTTP API requests manually (e.g. using a different HTTP client), this method

--- a/src/main/java/com/pusher/rest/PusherAbstract.java
+++ b/src/main/java/com/pusher/rest/PusherAbstract.java
@@ -22,7 +22,14 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-abstract class PusherAbstract<T> {
+/**
+ * Parent class for Pusher clients, deals with anything that isn't IO related.
+ *
+ * @param <T> The return type of the IO calls.
+ *
+ * See {@link Pusher} for the synchronous implementation, {@link PusherAsync} for the asynchronous implementation.
+ */
+public abstract class PusherAbstract<T> {
     protected static final Gson BODY_SERIALISER = new GsonBuilder()
             .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
             .create();

--- a/src/main/java/com/pusher/rest/PusherAsync.java
+++ b/src/main/java/com/pusher/rest/PusherAsync.java
@@ -92,7 +92,7 @@ public class PusherAsync extends PusherAbstract<CompletableFuture<Result>> {
      * <pre>
      * pusher.configureHttpClient(
      *     config()
-     *         .setProxyServer(new ProxyServer(...))
+     *         .setProxyServer(proxyServer("127.0.0.1", 38080))
      *         .setMaxRequestRetry(5)
      * );
      * </pre>

--- a/src/main/java/com/pusher/rest/PusherAsync.java
+++ b/src/main/java/com/pusher/rest/PusherAsync.java
@@ -49,6 +49,8 @@ import static org.asynchttpclient.Dsl.config;
  *   }
  * });
  * </pre>
+ *
+ * See {@link Pusher} for the synchronous implementation.
  */
 public class PusherAsync extends PusherAbstract<CompletableFuture<Result>> {
 

--- a/src/main/java/com/pusher/rest/PusherAsync.java
+++ b/src/main/java/com/pusher/rest/PusherAsync.java
@@ -1,0 +1,535 @@
+package com.pusher.rest;
+
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.pusher.rest.data.AuthData;
+import com.pusher.rest.data.Event;
+import com.pusher.rest.data.EventBatch;
+import com.pusher.rest.data.PresenceUser;
+import com.pusher.rest.data.Result;
+import com.pusher.rest.data.TriggerData;
+import com.pusher.rest.data.Validity;
+import com.pusher.rest.marshaller.DataMarshaller;
+import com.pusher.rest.marshaller.DefaultDataMarshaller;
+import com.pusher.rest.util.Prerequisites;
+import org.apache.http.entity.StringEntity;
+import org.asynchttpclient.AsyncHttpClient;
+import org.asynchttpclient.DefaultAsyncHttpClientConfig;
+import org.asynchttpclient.Request;
+import org.asynchttpclient.RequestBuilder;
+import org.asynchttpclient.util.HttpConstants;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.asynchttpclient.Dsl.asyncHttpClient;
+import static org.asynchttpclient.Dsl.config;
+
+/**
+ * A library for interacting with the Pusher HTTP API asynchronously.
+ * <p>
+ * See http://github.com/pusher/pusher-http-java for an overview
+ * <p>
+ * Essentially:
+ * <pre>
+ * // Init
+ * PusherAsync pusher = new PusherAsync(APP_ID, KEY, SECRET);
+ *
+ * // Publish
+ * CompletableFuture&lt;Result> futureTriggerResult = pusher.trigger("my-channel", "my-eventname", myPojoForSerialisation);
+ * triggerResult.thenAccept(triggerResult -> {
+ *   if (triggerResult.getStatus() == Status.SUCCESS) {
+ *     // request was successful
+ *   } else {
+ *     // something went wrong with the request
+ *   }
+ * });
+ *
+ * // Query
+ * CompletableFuture&lt;Result> futureChannelListResult = pusher.get("/channels");
+ * futureChannelListResult.thenAccept(triggerResult -> {
+ *   if (triggerResult.getStatus() == Status.SUCCESS) {
+ *     String channelListAsJson = channelListResult.getMessage();
+ *     // etc.
+ *   } else {
+ *     // something went wrong with the request
+ *   }
+ * });
+ * </pre>
+ */
+public class PusherAsync {
+    private static final Gson BODY_SERIALISER = new GsonBuilder()
+            .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+            .create();
+
+    private static final Pattern HEROKU_URL = Pattern.compile("(https?)://(.+):(.+)@(.+:?.*)/apps/(.+)");
+
+    private final String appId;
+    private final String key;
+    private final String secret;
+
+    private String host = "api.pusherapp.com";
+    private String scheme = "http";
+
+    private AsyncHttpClient client;
+    private DataMarshaller dataMarshaller;
+
+    /**
+     * Construct an instance of the Pusher object through which you may interact with the Pusher API.
+     * <p>
+     * The parameters to use are found on your dashboard at https://app.pusher.com and are specific per App.
+     * <p>
+     *
+     * @param appId  The ID of the App you will to interact with.
+     * @param key    The App Key, the same key you give to websocket clients to identify your app when they connect to Pusher.
+     * @param secret The App Secret. Used to sign requests to the API, this should be treated as sensitive and not distributed.
+     */
+    public PusherAsync(final String appId, final String key, final String secret) {
+        Prerequisites.nonEmpty("appId", appId);
+        Prerequisites.nonEmpty("key", key);
+        Prerequisites.nonEmpty("secret", secret);
+        Prerequisites.isValidSha256Key("secret", secret);
+
+        this.appId = appId;
+        this.key = key;
+        this.secret = secret;
+
+        configure();
+    }
+
+    public PusherAsync(final String url) {
+        Prerequisites.nonNull("url", url);
+
+        final Matcher m = HEROKU_URL.matcher(url);
+        if (m.matches()) {
+            this.scheme = m.group(1);
+            this.key = m.group(2);
+            this.secret = m.group(3);
+            this.host = m.group(4);
+            this.appId = m.group(5);
+        } else {
+            throw new IllegalArgumentException("URL '" + url + "' does not match pattern '<scheme>://<key>:<secret>@<host>[:<port>]/apps/<appId>'");
+        }
+
+        Prerequisites.isValidSha256Key("secret", secret);
+        configure();
+    }
+
+    private void configure() {
+        configureHttpClient(config());
+        this.dataMarshaller = new DefaultDataMarshaller();
+    }
+
+    /*
+     * CONFIG
+     */
+
+    /**
+     * For testing or specifying an alternative cluster. See also {@link #setCluster(String)} for the latter.
+     * <p>
+     * Default: api.pusherapp.com
+     *
+     * @param host the API endpoint host
+     */
+    public void setHost(final String host) {
+        Prerequisites.nonNull("host", host);
+
+        this.host = host;
+    }
+
+    /**
+     * For Specifying an alternative cluster.
+     * <p>
+     * See also {@link #setHost(String)} for targetting an arbitrary endpoint.
+     *
+     * @param cluster the Pusher cluster to target
+     */
+    public void setCluster(final String cluster) {
+        Prerequisites.nonNull("cluster", cluster);
+
+        this.host = "api-" + cluster + ".pusher.com";
+    }
+
+    /**
+     * Set whether to use a secure connection to the API (SSL).
+     * <p>
+     * Authentication is secure even without this option, requests cannot be faked or replayed with access
+     * to their plain text, a secure connection is only required if the requests or responses contain
+     * sensitive information.
+     * <p>
+     * Default: false
+     *
+     * @param encrypted whether to use SSL to contact the API
+     */
+    public void setEncrypted(final boolean encrypted) {
+        this.scheme = encrypted ? "https" : "http";
+    }
+
+    /**
+     * Set a custom marshaller used to serialize Objects passed to {@link #trigger(List, String, Object)}
+     * and friends.
+     * <p>
+     * By default, the library marshals the objects provided to JSON using the Gson library
+     * (see https://code.google.com/p/google-gson/ for more details). By providing an instance
+     * here, you may exert control over the marshalling, for example choosing how Java property
+     * names are mapped on to the field names in the JSON representation, allowing you to match
+     * the expected scheme on the client side.
+     *
+     * @param marshaller a DataMarshaller instance configured to your liking
+     */
+    public void setDataMarshaller(final DataMarshaller marshaller) {
+        this.dataMarshaller = marshaller;
+    }
+
+    /**
+     * Configure the HttpClient instance which will be used for making calls to the Pusher API.
+     * <p>
+     * This method allows almost complete control over all aspects of the HTTP client, including
+     * <ul>
+     * <li>proxy host</li>
+     * <li>connection pooling and reuse strategies</li>
+     * <li>automatic retry and backoff strategies</li>
+     * </ul>
+     * <p>
+     * e.g.
+     * <pre>
+     * pusher.configureHttpClient(
+     *     config()
+     *         .setProxyServer(new ProxyServer(...))
+     *         .setMaxRequestRetry(5)
+     * );
+     * </pre>
+     *
+     * @param builder an {@link DefaultAsyncHttpClientConfig.Builder} with which to configure
+     *                the internal HTTP client
+     */
+    public void configureHttpClient(final DefaultAsyncHttpClientConfig.Builder builder) {
+        try {
+            if (client != null && !client.isClosed()) client.close();
+        } catch (IOException e) {
+            // Not a lot useful we can do here
+        }
+
+        this.client = asyncHttpClient(builder);
+    }
+
+    /**
+     * This method provides an override point if the default Gson based serialisation is absolutely
+     * unsuitable for your use case, even with customisation of the Gson instance doing the serialisation.
+     * <p>
+     * For example, in the simplest case, you might already have your data pre-serialised and simply want
+     * to elide the default serialisation:
+     * <pre>
+     * Pusher pusher = new Pusher(appId, key, secret) {
+     *     protected String serialise(final Object data) {
+     *         return (String)data;
+     *     }
+     * };
+     *
+     * pusher.trigger("my-channel", "my-event", "{\"my-data\":\"my-value\"}");
+     * </pre>
+     *
+     * @param data an unserialised event payload
+     * @return a serialised event payload
+     */
+    protected String serialise(final Object data) {
+        return dataMarshaller.marshal(data);
+    }
+
+    /*
+     * REST
+     */
+
+    /**
+     * Publish a message to a single channel.
+     * <p>
+     * The message data should be a POJO, which will be serialised to JSON for submission.
+     * Use {@link #setDataMarshaller(DataMarshaller)} to control the serialisation
+     * <p>
+     * Note that if you do not wish to create classes specifically for the purpose of specifying
+     * the message payload, use Map&lt;String, Object&gt;. These maps will nest just fine.
+     *
+     * @param channel   the channel name on which to trigger the event
+     * @param eventName the name given to the event
+     * @param data      an object which will be serialised to create the event body
+     * @return a {@link Result} object encapsulating the success state and response to the request
+     */
+    public CompletableFuture<Result> trigger(final String channel, final String eventName, final Object data) {
+        return trigger(channel, eventName, data, null);
+    }
+
+    /**
+     * Publish identical messages to multiple channels.
+     *
+     * @param channels  the channel names on which to trigger the event
+     * @param eventName the name given to the event
+     * @param data      an object which will be serialised to create the event body
+     * @return a {@link Result} object encapsulating the success state and response to the request
+     */
+    public CompletableFuture<Result> trigger(final List<String> channels, final String eventName, final Object data) {
+        return trigger(channels, eventName, data, null);
+    }
+
+    /**
+     * Publish a message to a single channel, excluding the specified socketId from receiving the message.
+     *
+     * @param channel   the channel name on which to trigger the event
+     * @param eventName the name given to the event
+     * @param data      an object which will be serialised to create the event body
+     * @param socketId  a socket id which should be excluded from receiving the event
+     * @return a {@link Result} object encapsulating the success state and response to the request
+     */
+    public CompletableFuture<Result> trigger(final String channel, final String eventName, final Object data, final String socketId) {
+        return trigger(Collections.singletonList(channel), eventName, data, socketId);
+    }
+
+    /**
+     * Publish identical messages to multiple channels, excluding the specified socketId from receiving the message.
+     *
+     * @param channels  the channel names on which to trigger the event
+     * @param eventName the name given to the event
+     * @param data      an object which will be serialised to create the event body
+     * @param socketId  a socket id which should be excluded from receiving the event
+     * @return a {@link Result} object encapsulating the success state and response to the request
+     */
+    public CompletableFuture<Result> trigger(final List<String> channels, final String eventName, final Object data, final String socketId) {
+        Prerequisites.nonNull("channels", channels);
+        Prerequisites.nonNull("eventName", eventName);
+        Prerequisites.nonNull("data", data);
+        Prerequisites.maxLength("channels", 100, channels);
+        Prerequisites.noNullMembers("channels", channels);
+        Prerequisites.areValidChannels(channels);
+        Prerequisites.isValidSocketId(socketId);
+
+        final String body = BODY_SERIALISER.toJson(new TriggerData(channels, eventName, serialise(data), socketId));
+
+        return post("/events", body);
+    }
+
+    /**
+     * Publish a batch of different events with a single API call.
+     * <p>
+     * The batch is limited to 10 events on our multi-tenant clusters.
+     *
+     * @param batch a list of events to publish
+     * @return a {@link Result} object encapsulating the success state and response to the request
+     */
+    public CompletableFuture<Result> trigger(final List<Event> batch) {
+        final List<Event> eventsWithSerialisedBodies = new ArrayList<Event>(batch.size());
+        for (final Event e : batch) {
+            eventsWithSerialisedBodies.add(
+                    new Event(
+                            e.getChannel(),
+                            e.getName(),
+                            serialise(e.getData()),
+                            e.getSocketId()
+                    )
+            );
+        }
+        final String body = BODY_SERIALISER.toJson(new EventBatch(eventsWithSerialisedBodies));
+
+        return post("/batch_events", body);
+    }
+
+    /**
+     * Make a generic HTTP call to the Pusher API.
+     * <p>
+     * See: http://pusher.com/docs/rest_api
+     * <p>
+     * NOTE: the path specified here is relative to that of your app. For example, to access
+     * the channel list for your app, simply pass "/channels". Do not include the "/apps/[appId]"
+     * at the beginning of the path.
+     *
+     * @param path the path (e.g. /channels) to query
+     * @return a {@link Result} object encapsulating the success state and response to the request
+     */
+    public CompletableFuture<Result> get(final String path) {
+        return get(path, Collections.<String, String>emptyMap());
+    }
+
+    /**
+     * Make a generic HTTP call to the Pusher API.
+     * <p>
+     * See: http://pusher.com/docs/rest_api
+     * <p>
+     * Parameters should be a map of query parameters for the HTTP call, and may be null
+     * if none are required.
+     * <p>
+     * NOTE: the path specified here is relative to that of your app. For example, to access
+     * the channel list for your app, simply pass "/channels". Do not include the "/apps/[appId]"
+     * at the beginning of the path.
+     *
+     * @param path       the path (e.g. /channels) to query
+     * @param parameters query parameters to submit with the request
+     * @return a {@link Result} object encapsulating the success state and response to the request
+     */
+    public CompletableFuture<Result> get(final String path, final Map<String, String> parameters) {
+        final String fullPath = "/apps/" + appId + path;
+        final URI uri = SignatureUtil.uri("GET", scheme, host, fullPath, null, key, secret, parameters);
+
+        Request request = new RequestBuilder(HttpConstants.Methods.GET)
+                .setUrl(uri.toString())
+                .build();
+
+        return httpCall(request);
+    }
+
+    /**
+     * Make a generic HTTP call to the Pusher API.
+     * <p>
+     * The body should be a UTF-8 encoded String
+     * <p>
+     * See: http://pusher.com/docs/rest_api
+     * <p>
+     * NOTE: the path specified here is relative to that of your app. For example, to access
+     * the channel list for your app, simply pass "/channels". Do not include the "/apps/[appId]"
+     * at the beginning of the path.
+     *
+     * @param path the path (e.g. /channels) to submit
+     * @param body the body to submit
+     * @return a {@link Result} object encapsulating the success state and response to the request
+     */
+    public CompletableFuture<Result> post(final String path, final String body) {
+        final String fullPath = "/apps/" + appId + path;
+        final URI uri = SignatureUtil.uri("POST", scheme, host, fullPath, body, key, secret, Collections.<String, String>emptyMap());
+
+        final StringEntity bodyEntity = new StringEntity(body, "UTF-8");
+        bodyEntity.setContentType("application/json");
+
+        Request request = new RequestBuilder(HttpConstants.Methods.POST)
+                .setUrl(uri.toString())
+                .setBody(body)
+                .addHeader("Content-Type", "application/json")
+                .build();
+
+        return httpCall(request);
+    }
+
+    CompletableFuture<Result> httpCall(final Request request) {
+        return client
+                .prepareRequest(request)
+                .execute()
+                .toCompletableFuture()
+                .thenApply(response -> Result.fromHttpCode(response.getStatusCode(), response.getResponseBody(UTF_8)))
+                .exceptionally(Result::fromThrowable);
+    }
+
+    /**
+     * If you wanted to send the HTTP API requests manually (e.g. using a different HTTP client), this method
+     * will return a java.net.URI which includes all of the appropriate query parameters which sign the request.
+     *
+     * @param method the HTTP method, e.g. GET, POST
+     * @param path   the HTTP path, e.g. /channels
+     * @param body   the HTTP request body, if there is one (otherwise pass null)
+     * @return a URI object which includes the necessary query params for request authentication
+     */
+    public URI signedUri(final String method, final String path, final String body) {
+        return signedUri(method, path, body, Collections.<String, String>emptyMap());
+    }
+
+    /**
+     * If you wanted to send the HTTP API requests manually (e.g. using a different HTTP client), this method
+     * will return a java.net.URI which includes all of the appropriate query parameters which sign the request.
+     * <p>
+     * Note that any further query parameters you wish to be add must be specified here, as they form part of the signature.
+     *
+     * @param method     the HTTP method, e.g. GET, POST
+     * @param path       the HTTP path, e.g. /channels
+     * @param body       the HTTP request body, if there is one (otherwise pass null)
+     * @param parameters HTTP query parameters to be included in the request
+     * @return a URI object which includes the necessary query params for request authentication
+     */
+    public URI signedUri(final String method, final String path, final String body, final Map<String, String> parameters) {
+        return SignatureUtil.uri(method, scheme, host, path, body, key, secret, parameters);
+    }
+
+    /*
+     * CHANNEL AUTHENTICATION
+     */
+
+    /**
+     * Generate authentication response to authorise a user on a private channel
+     * <p>
+     * The return value is the complete body which should be returned to a client requesting authorisation.
+     *
+     * @param socketId the socket id of the connection to authenticate
+     * @param channel  the name of the channel which the socket id should be authorised to join
+     * @return an authentication string, suitable for return to the requesting client
+     */
+    public String authenticate(final String socketId, final String channel) {
+        Prerequisites.nonNull("socketId", socketId);
+        Prerequisites.nonNull("channel", channel);
+        Prerequisites.isValidChannel(channel);
+        Prerequisites.isValidSocketId(socketId);
+
+        if (channel.startsWith("presence-")) {
+            throw new IllegalArgumentException("This method is for private channels, use authenticate(String, String, PresenceUser) to authenticate for a presence channel.");
+        }
+        if (!channel.startsWith("private-")) {
+            throw new IllegalArgumentException("Authentication is only applicable to private and presence channels");
+        }
+
+        final String signature = SignatureUtil.sign(socketId + ":" + channel, secret);
+        return BODY_SERIALISER.toJson(new AuthData(key, signature));
+    }
+
+    /**
+     * Generate authentication response to authorise a user on a presence channel
+     * <p>
+     * The return value is the complete body which should be returned to a client requesting authorisation.
+     *
+     * @param socketId the socket id of the connection to authenticate
+     * @param channel  the name of the channel which the socket id should be authorised to join
+     * @param user     a {@link PresenceUser} object which represents the channel data to be associated with the user
+     * @return an authentication string, suitable for return to the requesting client
+     */
+    public String authenticate(final String socketId, final String channel, final PresenceUser user) {
+        Prerequisites.nonNull("socketId", socketId);
+        Prerequisites.nonNull("channel", channel);
+        Prerequisites.nonNull("user", user);
+        Prerequisites.isValidChannel(channel);
+        Prerequisites.isValidSocketId(socketId);
+
+        if (channel.startsWith("private-")) {
+            throw new IllegalArgumentException("This method is for presence channels, use authenticate(String, String) to authenticate for a private channel.");
+        }
+        if (!channel.startsWith("presence-")) {
+            throw new IllegalArgumentException("Authentication is only applicable to private and presence channels");
+        }
+
+        final String channelData = BODY_SERIALISER.toJson(user);
+        final String signature = SignatureUtil.sign(socketId + ":" + channel + ":" + channelData, secret);
+        return BODY_SERIALISER.toJson(new AuthData(key, signature, channelData));
+    }
+
+    /*
+     * WEBHOOK VALIDATION
+     */
+
+    /**
+     * Check the signature on a webhook received from Pusher
+     *
+     * @param xPusherKeyHeader       the X-Pusher-Key header as received in the webhook request
+     * @param xPusherSignatureHeader the X-Pusher-Signature header as received in the webhook request
+     * @param body                   the webhook body
+     * @return enum representing the possible validities of the webhook request
+     */
+    public Validity validateWebhookSignature(final String xPusherKeyHeader, final String xPusherSignatureHeader, final String body) {
+        if (!xPusherKeyHeader.trim().equals(key)) {
+            // We can't validate the signature, because it was signed with a different key to the one we were initialised with.
+            return Validity.SIGNED_WITH_WRONG_KEY;
+        }
+
+        final String recalculatedSignature = SignatureUtil.sign(body, secret);
+        return xPusherSignatureHeader.trim().equals(recalculatedSignature) ? Validity.VALID : Validity.INVALID;
+    }
+}

--- a/src/main/java/com/pusher/rest/PusherAsync.java
+++ b/src/main/java/com/pusher/rest/PusherAsync.java
@@ -1,7 +1,6 @@
 package com.pusher.rest;
 
 import com.pusher.rest.data.Result;
-import org.apache.http.entity.StringEntity;
 import org.asynchttpclient.AsyncHttpClient;
 import org.asynchttpclient.DefaultAsyncHttpClientConfig;
 import org.asynchttpclient.Request;
@@ -10,8 +9,6 @@ import org.asynchttpclient.util.HttpConstants;
 
 import java.io.IOException;
 import java.net.URI;
-import java.util.Collections;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -119,26 +116,17 @@ public class PusherAsync extends PusherAbstract<CompletableFuture<Result>> {
      */
 
     @Override
-    public CompletableFuture<Result> get(final String path, final Map<String, String> parameters) {
-        final String fullPath = "/apps/" + appId + path;
-        final URI uri = SignatureUtil.uri("GET", scheme, host, fullPath, null, key, secret, parameters);
-
-        Request request = new RequestBuilder(HttpConstants.Methods.GET)
-                .setUrl(uri.toString())
-                .build();
+    protected CompletableFuture<Result> doGet(URI uri) {
+        final Request request = new RequestBuilder(HttpConstants.Methods.GET)
+            .setUrl(uri.toString())
+            .build();
 
         return httpCall(request);
     }
 
     @Override
-    public CompletableFuture<Result> post(final String path, final String body) {
-        final String fullPath = "/apps/" + appId + path;
-        final URI uri = SignatureUtil.uri("POST", scheme, host, fullPath, body, key, secret, Collections.<String, String>emptyMap());
-
-        final StringEntity bodyEntity = new StringEntity(body, "UTF-8");
-        bodyEntity.setContentType("application/json");
-
-        Request request = new RequestBuilder(HttpConstants.Methods.POST)
+    protected CompletableFuture<Result> doPost(URI uri, String body) {
+        final Request request = new RequestBuilder(HttpConstants.Methods.POST)
                 .setUrl(uri.toString())
                 .setBody(body)
                 .addHeader("Content-Type", "application/json")

--- a/src/main/java/com/pusher/rest/PusherAsync.java
+++ b/src/main/java/com/pusher/rest/PusherAsync.java
@@ -1,18 +1,6 @@
 package com.pusher.rest;
 
-import com.google.gson.FieldNamingPolicy;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.pusher.rest.data.AuthData;
-import com.pusher.rest.data.Event;
-import com.pusher.rest.data.EventBatch;
-import com.pusher.rest.data.PresenceUser;
 import com.pusher.rest.data.Result;
-import com.pusher.rest.data.TriggerData;
-import com.pusher.rest.data.Validity;
-import com.pusher.rest.marshaller.DataMarshaller;
-import com.pusher.rest.marshaller.DefaultDataMarshaller;
-import com.pusher.rest.util.Prerequisites;
 import org.apache.http.entity.StringEntity;
 import org.asynchttpclient.AsyncHttpClient;
 import org.asynchttpclient.DefaultAsyncHttpClientConfig;
@@ -22,13 +10,9 @@ import org.asynchttpclient.util.HttpConstants;
 
 import java.io.IOException;
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.asynchttpclient.Dsl.asyncHttpClient;
@@ -66,22 +50,9 @@ import static org.asynchttpclient.Dsl.config;
  * });
  * </pre>
  */
-public class PusherAsync {
-    private static final Gson BODY_SERIALISER = new GsonBuilder()
-            .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
-            .create();
-
-    private static final Pattern HEROKU_URL = Pattern.compile("(https?)://(.+):(.+)@(.+:?.*)/apps/(.+)");
-
-    private final String appId;
-    private final String key;
-    private final String secret;
-
-    private String host = "api.pusherapp.com";
-    private String scheme = "http";
+public class PusherAsync extends PusherAbstract<CompletableFuture<Result>> {
 
     private AsyncHttpClient client;
-    private DataMarshaller dataMarshaller;
 
     /**
      * Construct an instance of the Pusher object through which you may interact with the Pusher API.
@@ -94,39 +65,13 @@ public class PusherAsync {
      * @param secret The App Secret. Used to sign requests to the API, this should be treated as sensitive and not distributed.
      */
     public PusherAsync(final String appId, final String key, final String secret) {
-        Prerequisites.nonEmpty("appId", appId);
-        Prerequisites.nonEmpty("key", key);
-        Prerequisites.nonEmpty("secret", secret);
-        Prerequisites.isValidSha256Key("secret", secret);
-
-        this.appId = appId;
-        this.key = key;
-        this.secret = secret;
-
-        configure();
+        super(appId, key, secret);
+        configureHttpClient(config());
     }
 
     public PusherAsync(final String url) {
-        Prerequisites.nonNull("url", url);
-
-        final Matcher m = HEROKU_URL.matcher(url);
-        if (m.matches()) {
-            this.scheme = m.group(1);
-            this.key = m.group(2);
-            this.secret = m.group(3);
-            this.host = m.group(4);
-            this.appId = m.group(5);
-        } else {
-            throw new IllegalArgumentException("URL '" + url + "' does not match pattern '<scheme>://<key>:<secret>@<host>[:<port>]/apps/<appId>'");
-        }
-
-        Prerequisites.isValidSha256Key("secret", secret);
-        configure();
-    }
-
-    private void configure() {
+        super(url);
         configureHttpClient(config());
-        this.dataMarshaller = new DefaultDataMarshaller();
     }
 
     /*
@@ -134,64 +79,7 @@ public class PusherAsync {
      */
 
     /**
-     * For testing or specifying an alternative cluster. See also {@link #setCluster(String)} for the latter.
-     * <p>
-     * Default: api.pusherapp.com
-     *
-     * @param host the API endpoint host
-     */
-    public void setHost(final String host) {
-        Prerequisites.nonNull("host", host);
-
-        this.host = host;
-    }
-
-    /**
-     * For Specifying an alternative cluster.
-     * <p>
-     * See also {@link #setHost(String)} for targetting an arbitrary endpoint.
-     *
-     * @param cluster the Pusher cluster to target
-     */
-    public void setCluster(final String cluster) {
-        Prerequisites.nonNull("cluster", cluster);
-
-        this.host = "api-" + cluster + ".pusher.com";
-    }
-
-    /**
-     * Set whether to use a secure connection to the API (SSL).
-     * <p>
-     * Authentication is secure even without this option, requests cannot be faked or replayed with access
-     * to their plain text, a secure connection is only required if the requests or responses contain
-     * sensitive information.
-     * <p>
-     * Default: false
-     *
-     * @param encrypted whether to use SSL to contact the API
-     */
-    public void setEncrypted(final boolean encrypted) {
-        this.scheme = encrypted ? "https" : "http";
-    }
-
-    /**
-     * Set a custom marshaller used to serialize Objects passed to {@link #trigger(List, String, Object)}
-     * and friends.
-     * <p>
-     * By default, the library marshals the objects provided to JSON using the Gson library
-     * (see https://code.google.com/p/google-gson/ for more details). By providing an instance
-     * here, you may exert control over the marshalling, for example choosing how Java property
-     * names are mapped on to the field names in the JSON representation, allowing you to match
-     * the expected scheme on the client side.
-     *
-     * @param marshaller a DataMarshaller instance configured to your liking
-     */
-    public void setDataMarshaller(final DataMarshaller marshaller) {
-        this.dataMarshaller = marshaller;
-    }
-
-    /**
-     * Configure the HttpClient instance which will be used for making calls to the Pusher API.
+     * Configure the AsyncHttpClient instance which will be used for making calls to the Pusher API.
      * <p>
      * This method allows almost complete control over all aspects of the HTTP client, including
      * <ul>
@@ -214,7 +102,9 @@ public class PusherAsync {
      */
     public void configureHttpClient(final DefaultAsyncHttpClientConfig.Builder builder) {
         try {
-            if (client != null && !client.isClosed()) client.close();
+            if (client != null && !client.isClosed()) {
+                client.close();
+            }
         } catch (IOException e) {
             // Not a lot useful we can do here
         }
@@ -222,156 +112,11 @@ public class PusherAsync {
         this.client = asyncHttpClient(builder);
     }
 
-    /**
-     * This method provides an override point if the default Gson based serialisation is absolutely
-     * unsuitable for your use case, even with customisation of the Gson instance doing the serialisation.
-     * <p>
-     * For example, in the simplest case, you might already have your data pre-serialised and simply want
-     * to elide the default serialisation:
-     * <pre>
-     * Pusher pusher = new Pusher(appId, key, secret) {
-     *     protected String serialise(final Object data) {
-     *         return (String)data;
-     *     }
-     * };
-     *
-     * pusher.trigger("my-channel", "my-event", "{\"my-data\":\"my-value\"}");
-     * </pre>
-     *
-     * @param data an unserialised event payload
-     * @return a serialised event payload
-     */
-    protected String serialise(final Object data) {
-        return dataMarshaller.marshal(data);
-    }
-
     /*
      * REST
      */
 
-    /**
-     * Publish a message to a single channel.
-     * <p>
-     * The message data should be a POJO, which will be serialised to JSON for submission.
-     * Use {@link #setDataMarshaller(DataMarshaller)} to control the serialisation
-     * <p>
-     * Note that if you do not wish to create classes specifically for the purpose of specifying
-     * the message payload, use Map&lt;String, Object&gt;. These maps will nest just fine.
-     *
-     * @param channel   the channel name on which to trigger the event
-     * @param eventName the name given to the event
-     * @param data      an object which will be serialised to create the event body
-     * @return a {@link Result} object encapsulating the success state and response to the request
-     */
-    public CompletableFuture<Result> trigger(final String channel, final String eventName, final Object data) {
-        return trigger(channel, eventName, data, null);
-    }
-
-    /**
-     * Publish identical messages to multiple channels.
-     *
-     * @param channels  the channel names on which to trigger the event
-     * @param eventName the name given to the event
-     * @param data      an object which will be serialised to create the event body
-     * @return a {@link Result} object encapsulating the success state and response to the request
-     */
-    public CompletableFuture<Result> trigger(final List<String> channels, final String eventName, final Object data) {
-        return trigger(channels, eventName, data, null);
-    }
-
-    /**
-     * Publish a message to a single channel, excluding the specified socketId from receiving the message.
-     *
-     * @param channel   the channel name on which to trigger the event
-     * @param eventName the name given to the event
-     * @param data      an object which will be serialised to create the event body
-     * @param socketId  a socket id which should be excluded from receiving the event
-     * @return a {@link Result} object encapsulating the success state and response to the request
-     */
-    public CompletableFuture<Result> trigger(final String channel, final String eventName, final Object data, final String socketId) {
-        return trigger(Collections.singletonList(channel), eventName, data, socketId);
-    }
-
-    /**
-     * Publish identical messages to multiple channels, excluding the specified socketId from receiving the message.
-     *
-     * @param channels  the channel names on which to trigger the event
-     * @param eventName the name given to the event
-     * @param data      an object which will be serialised to create the event body
-     * @param socketId  a socket id which should be excluded from receiving the event
-     * @return a {@link Result} object encapsulating the success state and response to the request
-     */
-    public CompletableFuture<Result> trigger(final List<String> channels, final String eventName, final Object data, final String socketId) {
-        Prerequisites.nonNull("channels", channels);
-        Prerequisites.nonNull("eventName", eventName);
-        Prerequisites.nonNull("data", data);
-        Prerequisites.maxLength("channels", 100, channels);
-        Prerequisites.noNullMembers("channels", channels);
-        Prerequisites.areValidChannels(channels);
-        Prerequisites.isValidSocketId(socketId);
-
-        final String body = BODY_SERIALISER.toJson(new TriggerData(channels, eventName, serialise(data), socketId));
-
-        return post("/events", body);
-    }
-
-    /**
-     * Publish a batch of different events with a single API call.
-     * <p>
-     * The batch is limited to 10 events on our multi-tenant clusters.
-     *
-     * @param batch a list of events to publish
-     * @return a {@link Result} object encapsulating the success state and response to the request
-     */
-    public CompletableFuture<Result> trigger(final List<Event> batch) {
-        final List<Event> eventsWithSerialisedBodies = new ArrayList<Event>(batch.size());
-        for (final Event e : batch) {
-            eventsWithSerialisedBodies.add(
-                    new Event(
-                            e.getChannel(),
-                            e.getName(),
-                            serialise(e.getData()),
-                            e.getSocketId()
-                    )
-            );
-        }
-        final String body = BODY_SERIALISER.toJson(new EventBatch(eventsWithSerialisedBodies));
-
-        return post("/batch_events", body);
-    }
-
-    /**
-     * Make a generic HTTP call to the Pusher API.
-     * <p>
-     * See: http://pusher.com/docs/rest_api
-     * <p>
-     * NOTE: the path specified here is relative to that of your app. For example, to access
-     * the channel list for your app, simply pass "/channels". Do not include the "/apps/[appId]"
-     * at the beginning of the path.
-     *
-     * @param path the path (e.g. /channels) to query
-     * @return a {@link Result} object encapsulating the success state and response to the request
-     */
-    public CompletableFuture<Result> get(final String path) {
-        return get(path, Collections.<String, String>emptyMap());
-    }
-
-    /**
-     * Make a generic HTTP call to the Pusher API.
-     * <p>
-     * See: http://pusher.com/docs/rest_api
-     * <p>
-     * Parameters should be a map of query parameters for the HTTP call, and may be null
-     * if none are required.
-     * <p>
-     * NOTE: the path specified here is relative to that of your app. For example, to access
-     * the channel list for your app, simply pass "/channels". Do not include the "/apps/[appId]"
-     * at the beginning of the path.
-     *
-     * @param path       the path (e.g. /channels) to query
-     * @param parameters query parameters to submit with the request
-     * @return a {@link Result} object encapsulating the success state and response to the request
-     */
+    @Override
     public CompletableFuture<Result> get(final String path, final Map<String, String> parameters) {
         final String fullPath = "/apps/" + appId + path;
         final URI uri = SignatureUtil.uri("GET", scheme, host, fullPath, null, key, secret, parameters);
@@ -383,21 +128,7 @@ public class PusherAsync {
         return httpCall(request);
     }
 
-    /**
-     * Make a generic HTTP call to the Pusher API.
-     * <p>
-     * The body should be a UTF-8 encoded String
-     * <p>
-     * See: http://pusher.com/docs/rest_api
-     * <p>
-     * NOTE: the path specified here is relative to that of your app. For example, to access
-     * the channel list for your app, simply pass "/channels". Do not include the "/apps/[appId]"
-     * at the beginning of the path.
-     *
-     * @param path the path (e.g. /channels) to submit
-     * @param body the body to submit
-     * @return a {@link Result} object encapsulating the success state and response to the request
-     */
+    @Override
     public CompletableFuture<Result> post(final String path, final String body) {
         final String fullPath = "/apps/" + appId + path;
         final URI uri = SignatureUtil.uri("POST", scheme, host, fullPath, body, key, secret, Collections.<String, String>emptyMap());
@@ -421,115 +152,5 @@ public class PusherAsync {
                 .toCompletableFuture()
                 .thenApply(response -> Result.fromHttpCode(response.getStatusCode(), response.getResponseBody(UTF_8)))
                 .exceptionally(Result::fromThrowable);
-    }
-
-    /**
-     * If you wanted to send the HTTP API requests manually (e.g. using a different HTTP client), this method
-     * will return a java.net.URI which includes all of the appropriate query parameters which sign the request.
-     *
-     * @param method the HTTP method, e.g. GET, POST
-     * @param path   the HTTP path, e.g. /channels
-     * @param body   the HTTP request body, if there is one (otherwise pass null)
-     * @return a URI object which includes the necessary query params for request authentication
-     */
-    public URI signedUri(final String method, final String path, final String body) {
-        return signedUri(method, path, body, Collections.<String, String>emptyMap());
-    }
-
-    /**
-     * If you wanted to send the HTTP API requests manually (e.g. using a different HTTP client), this method
-     * will return a java.net.URI which includes all of the appropriate query parameters which sign the request.
-     * <p>
-     * Note that any further query parameters you wish to be add must be specified here, as they form part of the signature.
-     *
-     * @param method     the HTTP method, e.g. GET, POST
-     * @param path       the HTTP path, e.g. /channels
-     * @param body       the HTTP request body, if there is one (otherwise pass null)
-     * @param parameters HTTP query parameters to be included in the request
-     * @return a URI object which includes the necessary query params for request authentication
-     */
-    public URI signedUri(final String method, final String path, final String body, final Map<String, String> parameters) {
-        return SignatureUtil.uri(method, scheme, host, path, body, key, secret, parameters);
-    }
-
-    /*
-     * CHANNEL AUTHENTICATION
-     */
-
-    /**
-     * Generate authentication response to authorise a user on a private channel
-     * <p>
-     * The return value is the complete body which should be returned to a client requesting authorisation.
-     *
-     * @param socketId the socket id of the connection to authenticate
-     * @param channel  the name of the channel which the socket id should be authorised to join
-     * @return an authentication string, suitable for return to the requesting client
-     */
-    public String authenticate(final String socketId, final String channel) {
-        Prerequisites.nonNull("socketId", socketId);
-        Prerequisites.nonNull("channel", channel);
-        Prerequisites.isValidChannel(channel);
-        Prerequisites.isValidSocketId(socketId);
-
-        if (channel.startsWith("presence-")) {
-            throw new IllegalArgumentException("This method is for private channels, use authenticate(String, String, PresenceUser) to authenticate for a presence channel.");
-        }
-        if (!channel.startsWith("private-")) {
-            throw new IllegalArgumentException("Authentication is only applicable to private and presence channels");
-        }
-
-        final String signature = SignatureUtil.sign(socketId + ":" + channel, secret);
-        return BODY_SERIALISER.toJson(new AuthData(key, signature));
-    }
-
-    /**
-     * Generate authentication response to authorise a user on a presence channel
-     * <p>
-     * The return value is the complete body which should be returned to a client requesting authorisation.
-     *
-     * @param socketId the socket id of the connection to authenticate
-     * @param channel  the name of the channel which the socket id should be authorised to join
-     * @param user     a {@link PresenceUser} object which represents the channel data to be associated with the user
-     * @return an authentication string, suitable for return to the requesting client
-     */
-    public String authenticate(final String socketId, final String channel, final PresenceUser user) {
-        Prerequisites.nonNull("socketId", socketId);
-        Prerequisites.nonNull("channel", channel);
-        Prerequisites.nonNull("user", user);
-        Prerequisites.isValidChannel(channel);
-        Prerequisites.isValidSocketId(socketId);
-
-        if (channel.startsWith("private-")) {
-            throw new IllegalArgumentException("This method is for presence channels, use authenticate(String, String) to authenticate for a private channel.");
-        }
-        if (!channel.startsWith("presence-")) {
-            throw new IllegalArgumentException("Authentication is only applicable to private and presence channels");
-        }
-
-        final String channelData = BODY_SERIALISER.toJson(user);
-        final String signature = SignatureUtil.sign(socketId + ":" + channel + ":" + channelData, secret);
-        return BODY_SERIALISER.toJson(new AuthData(key, signature, channelData));
-    }
-
-    /*
-     * WEBHOOK VALIDATION
-     */
-
-    /**
-     * Check the signature on a webhook received from Pusher
-     *
-     * @param xPusherKeyHeader       the X-Pusher-Key header as received in the webhook request
-     * @param xPusherSignatureHeader the X-Pusher-Signature header as received in the webhook request
-     * @param body                   the webhook body
-     * @return enum representing the possible validities of the webhook request
-     */
-    public Validity validateWebhookSignature(final String xPusherKeyHeader, final String xPusherSignatureHeader, final String body) {
-        if (!xPusherKeyHeader.trim().equals(key)) {
-            // We can't validate the signature, because it was signed with a different key to the one we were initialised with.
-            return Validity.SIGNED_WITH_WRONG_KEY;
-        }
-
-        final String recalculatedSignature = SignatureUtil.sign(body, secret);
-        return xPusherSignatureHeader.trim().equals(recalculatedSignature) ? Validity.VALID : Validity.INVALID;
     }
 }

--- a/src/main/java/com/pusher/rest/PusherAsync.java
+++ b/src/main/java/com/pusher/rest/PusherAsync.java
@@ -49,7 +49,7 @@ import static org.asynchttpclient.Dsl.config;
  *
  * See {@link Pusher} for the synchronous implementation.
  */
-public class PusherAsync extends PusherAbstract<CompletableFuture<Result>> {
+public class PusherAsync extends PusherAbstract<CompletableFuture<Result>> implements AutoCloseable {
 
     private AsyncHttpClient client;
 
@@ -101,10 +101,8 @@ public class PusherAsync extends PusherAbstract<CompletableFuture<Result>> {
      */
     public void configureHttpClient(final DefaultAsyncHttpClientConfig.Builder builder) {
         try {
-            if (client != null && !client.isClosed()) {
-                client.close();
-            }
-        } catch (IOException e) {
+            close();
+        } catch (final Exception e) {
             // Not a lot useful we can do here
         }
 
@@ -116,7 +114,7 @@ public class PusherAsync extends PusherAbstract<CompletableFuture<Result>> {
      */
 
     @Override
-    protected CompletableFuture<Result> doGet(URI uri) {
+    protected CompletableFuture<Result> doGet(final URI uri) {
         final Request request = new RequestBuilder(HttpConstants.Methods.GET)
             .setUrl(uri.toString())
             .build();
@@ -125,7 +123,7 @@ public class PusherAsync extends PusherAbstract<CompletableFuture<Result>> {
     }
 
     @Override
-    protected CompletableFuture<Result> doPost(URI uri, String body) {
+    protected CompletableFuture<Result> doPost(final URI uri, final String body) {
         final Request request = new RequestBuilder(HttpConstants.Methods.POST)
                 .setUrl(uri.toString())
                 .setBody(body)
@@ -143,4 +141,12 @@ public class PusherAsync extends PusherAbstract<CompletableFuture<Result>> {
                 .thenApply(response -> Result.fromHttpCode(response.getStatusCode(), response.getResponseBody(UTF_8)))
                 .exceptionally(Result::fromThrowable);
     }
+
+    @Override
+    public void close() throws Exception {
+        if (client != null && !client.isClosed()) {
+            client.close();
+        }
+    }
+
 }

--- a/src/main/java/com/pusher/rest/PusherAsync.java
+++ b/src/main/java/com/pusher/rest/PusherAsync.java
@@ -26,8 +26,8 @@ import static org.asynchttpclient.Dsl.config;
  * PusherAsync pusher = new PusherAsync(APP_ID, KEY, SECRET);
  *
  * // Publish
- * CompletableFuture&lt;Result> futureTriggerResult = pusher.trigger("my-channel", "my-eventname", myPojoForSerialisation);
- * triggerResult.thenAccept(triggerResult -> {
+ * CompletableFuture&lt;Result&gt; futureTriggerResult = pusher.trigger("my-channel", "my-eventname", myPojoForSerialisation);
+ * triggerResult.thenAccept(triggerResult -&gt; {
  *   if (triggerResult.getStatus() == Status.SUCCESS) {
  *     // request was successful
  *   } else {
@@ -36,8 +36,8 @@ import static org.asynchttpclient.Dsl.config;
  * });
  *
  * // Query
- * CompletableFuture&lt;Result> futureChannelListResult = pusher.get("/channels");
- * futureChannelListResult.thenAccept(triggerResult -> {
+ * CompletableFuture&lt;Result&gt; futureChannelListResult = pusher.get("/channels");
+ * futureChannelListResult.thenAccept(triggerResult -&gt; {
  *   if (triggerResult.getStatus() == Status.SUCCESS) {
  *     String channelListAsJson = channelListResult.getMessage();
  *     // etc.

--- a/src/main/java/com/pusher/rest/data/Result.java
+++ b/src/main/java/com/pusher/rest/data/Result.java
@@ -95,6 +95,16 @@ public class Result {
     }
 
     /**
+     * Factory method
+     *
+     * @param t cause
+     * @return a Result encapsulating the params
+     */
+    public static Result fromThrowable(final Throwable t) {
+        return new Result(Status.UNKNOWN_ERROR, null, t.toString());
+    }
+
+    /**
      * @return the enum classifying the result of the call
      */
     public Status getStatus() {

--- a/src/test/java/com/pusher/rest/PusherAsyncHttpTest.java
+++ b/src/test/java/com/pusher/rest/PusherAsyncHttpTest.java
@@ -1,0 +1,142 @@
+package com.pusher.rest;
+
+import com.pusher.rest.data.Result;
+import com.pusher.rest.data.Result.Status;
+import org.apache.http.HttpException;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.localserver.LocalTestServer;
+import org.apache.http.protocol.HttpContext;
+import org.apache.http.protocol.HttpRequestHandler;
+import org.asynchttpclient.Request;
+import org.asynchttpclient.RequestBuilder;
+import org.asynchttpclient.util.HttpConstants;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Tests which use a local server to check response handling
+ */
+public class PusherAsyncHttpTest {
+
+    private LocalTestServer server;
+    private Request request;
+
+    private int responseStatus = 200;
+    private String responseBody;
+
+    private PusherAsync p;
+
+    @BeforeEach
+    public void setup() throws Exception {
+        server = new LocalTestServer(null, null);
+        server.register("/*", new HttpRequestHandler() {
+            public void handle(HttpRequest request, HttpResponse response, HttpContext context) throws HttpException, IOException {
+                response.setStatusCode(responseStatus);
+                if (responseBody != null) {
+                    response.setEntity(new StringEntity(responseBody));
+                }
+            }
+        });
+
+        server.start();
+        request = new RequestBuilder(HttpConstants.Methods.GET)
+                .setUrl("http://" + server.getServiceAddress().getHostName() + ":" + server.getServiceAddress().getPort() + "/test")
+                .build();
+
+        p = new PusherAsync(PusherTest.APP_ID, PusherTest.KEY, PusherTest.SECRET);
+    }
+
+    @AfterEach
+    public void teardown() throws Exception {
+        server.stop();
+    }
+
+    @Test
+    public void successReturnsOkAndBody() throws Exception {
+        responseStatus = 200;
+        responseBody = "{}";
+
+        Result result = p.httpCall(request).get();
+        assertThat(result.getStatus(), is(Status.SUCCESS));
+        assertThat(result.getMessage(), is(responseBody));
+    }
+
+    @Test
+    public void status400ReturnsGenericErrorAndMessage() throws Exception {
+        responseStatus = 400;
+        responseBody = "A lolcat got all up in ur request";
+
+        Result result = p.httpCall(request).get();
+        assertThat(result.getStatus(), is(Status.CLIENT_ERROR));
+        assertThat(result.getMessage(), is(responseBody));
+    }
+
+    @Test
+    public void status401ReturnsAuthenticationErrorAndMessage() throws Exception {
+        responseStatus = 401;
+        responseBody = "Sorry, not in those shoes";
+
+        Result result = p.httpCall(request).get();
+        assertThat(result.getStatus(), is(Status.AUTHENTICATION_ERROR));
+        assertThat(result.getMessage(), is(responseBody));
+    }
+
+    @Test
+    public void status403ReturnsAuthenticationErrorAndMessage() throws Exception {
+        responseStatus = 403;
+        responseBody = "Sorry, not with all those friends";
+
+        Result result = p.httpCall(request).get();
+        assertThat(result.getStatus(), is(Status.MESSAGE_QUOTA_EXCEEDED));
+        assertThat(result.getMessage(), is(responseBody));
+    }
+
+    @Test
+    public void status404ReturnsNotFoundErrorAndMessage() throws Exception {
+        responseStatus = 404;
+        responseBody = "This is not the endpoint you are looking for";
+
+        Result result = p.httpCall(request).get();
+        assertThat(result.getStatus(), is(Status.NOT_FOUND));
+        assertThat(result.getMessage(), is(responseBody));
+    }
+
+    @Test
+    public void status500ReturnsServerErrorAndMessage() throws Exception {
+        responseStatus = 500;
+        responseBody = "Gary? Gary! It's still on fire!!";
+
+        Result result = p.httpCall(request).get();
+        assertThat(result.getStatus(), is(Status.SERVER_ERROR));
+        assertThat(result.getMessage(), is(responseBody));
+    }
+
+    @Test
+    public void status503ReturnsServerErrorAndMessage() throws Exception {
+        responseStatus = 503;
+        responseBody = "Gary, did you once again restart all the back-ends at once?!";
+
+        Result result = p.httpCall(request).get();
+        assertThat(result.getStatus(), is(Status.SERVER_ERROR));
+        assertThat(result.getMessage(), is(responseBody));
+    }
+
+    @Test
+    public void connectionRefusedReturnsNetworkError() throws Exception {
+        server.stop(); // don't listen for this test
+
+        Result result = p.httpCall(request).get();
+        assertThat(result.getStatus(), is(Status.UNKNOWN_ERROR));
+        assertThat(result.getMessage(), containsString("Connection refused"));
+    }
+}

--- a/src/test/java/com/pusher/rest/PusherAsyncHttpTest.java
+++ b/src/test/java/com/pusher/rest/PusherAsyncHttpTest.java
@@ -132,7 +132,7 @@ public class PusherAsyncHttpTest {
     }
 
     @Test
-    public void connectionRefusedReturnsNetworkError() throws Exception {
+    public void connectionRefusedReturnsUnknownError() throws Exception {
         server.stop(); // don't listen for this test
 
         Result result = p.httpCall(request).get();

--- a/src/test/java/com/pusher/rest/PusherChannelAuthTest.java
+++ b/src/test/java/com/pusher/rest/PusherChannelAuthTest.java
@@ -1,19 +1,18 @@
 package com.pusher.rest;
 
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-
-
-import java.util.Collections;
-
+import com.pusher.rest.data.PresenceUser;
+import com.pusher.rest.util.PusherNoHttp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import com.pusher.rest.data.PresenceUser;
+import java.util.Collections;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 public class PusherChannelAuthTest {
 
-    private final Pusher p = new Pusher("00001", "278d425bdf160c739803", "7ad3773142a6692b25b8");
+    private final PusherNoHttp p = new PusherNoHttp("00001", "278d425bdf160c739803", "7ad3773142a6692b25b8");
 
     @Test
     public void privateChannelAuth() {

--- a/src/test/java/com/pusher/rest/PusherTest.java
+++ b/src/test/java/com/pusher/rest/PusherTest.java
@@ -205,7 +205,8 @@ public class PusherTest {
     @Test
     public void channelListLimitOverLimit() {
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            final List<String> channels = Arrays.asList(new String[] { "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten", "eleven" });
+
+            final List<String> channels = Arrays.asList(new String[101]);
             p.trigger(channels, "event", Collections.singletonMap("name", "value"));
         });
 

--- a/src/test/java/com/pusher/rest/PusherTestUrlConfig.java
+++ b/src/test/java/com/pusher/rest/PusherTestUrlConfig.java
@@ -5,6 +5,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.lang.reflect.Field;
 
+import com.pusher.rest.util.PusherNoHttp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -12,7 +13,7 @@ public class PusherTestUrlConfig {
 
     @Test
     public void testUrl() throws Exception {
-        Pusher p = new Pusher("https://key:secret@api.example.com:4433/apps/00001");
+        PusherNoHttp p = new PusherNoHttp("https://key:secret@api.example.com:4433/apps/00001");
 
         assertField(p, "scheme", "https");
         assertField(p, "key", "key");
@@ -23,7 +24,7 @@ public class PusherTestUrlConfig {
 
     @Test
     public void testUrlNoPort() throws Exception {
-        Pusher p = new Pusher("http://key:secret@api.example.com/apps/00001");
+        PusherNoHttp p = new PusherNoHttp("http://key:secret@api.example.com/apps/00001");
 
         assertField(p, "scheme", "http");
         assertField(p, "key", "key");
@@ -35,33 +36,33 @@ public class PusherTestUrlConfig {
     @Test
     public void testUrlMissingField() throws Exception {
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            new Pusher("https://key@api.example.com:4433/apps/appId");
+            new PusherNoHttp("https://key@api.example.com:4433/apps/appId");
         });
     }
 
     @Test
     public void testUrlEmptySecret() throws Exception {
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            new Pusher("https://key:@api.example.com:4433/apps/appId");
+            new PusherNoHttp("https://key:@api.example.com:4433/apps/appId");
         });
     }
 
     @Test
     public void testUrlEmptyKey() throws Exception {
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            new Pusher("https://:secret@api.example.com:4433/apps/appId");
+            new PusherNoHttp("https://:secret@api.example.com:4433/apps/appId");
         });
     }
 
     @Test
     public void testUrlInvalidScheme() throws Exception {
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            new Pusher("telnet://key:secret@api.example.com:4433/apps/appId");
+            new PusherNoHttp("telnet://key:secret@api.example.com:4433/apps/appId");
         });
     }
 
-    private static <V> void assertField(final Object o, final String fieldName, final V expected) throws Exception {
-        final Field field = o.getClass().getDeclaredField(fieldName);
+    private static <T extends PusherAbstract<?>, V> void assertField(final T o, final String fieldName, final V expected) throws Exception {
+        final Field field = PusherAbstract.class.getDeclaredField(fieldName);
         field.setAccessible(true);
         final V actual = (V)field.get(o);
 

--- a/src/test/java/com/pusher/rest/util/PusherNoHttp.java
+++ b/src/test/java/com/pusher/rest/util/PusherNoHttp.java
@@ -1,0 +1,27 @@
+package com.pusher.rest.util;
+
+import com.pusher.rest.PusherAbstract;
+
+import java.net.URI;
+
+public class PusherNoHttp extends PusherAbstract<Object> {
+
+    public PusherNoHttp(final String appId, final String key, final String secret) {
+        super(appId, key, secret);
+    }
+
+    public PusherNoHttp(final String url) {
+        super(url);
+    }
+
+    @Override
+    protected Object doGet(final URI uri) {
+        throw new IllegalStateException("Shouldn't have been called, HTTP level not implemented");
+    }
+
+    @Override
+    protected Object doPost(final URI uri, final String body) {
+        throw new IllegalStateException("Shouldn't have been called, HTTP level not implemented");
+    }
+
+}


### PR DESCRIPTION
Allowing non-blocking HTTP calls by adding `PusherAsync` based on [AHC](https://github.com/AsyncHttpClient/async-http-client).

Closes https://github.com/pusher/pusher-http-java/issues/37.

Factored shared code between the existing `Pusher` and the new `PusherAsync` into `PusherAbstract<T>`, where `T` is the return type of the HTTP calls (respectively `Result` and `CompletableFuture<Result>`).

Should be fully backward compatible.

Tried to follow existing code/doc style.