### PR TITLE
Use SecureRandom.nextBytes instead of SecureRandom.generateSeed

### DIFF
--- a/src/main/java/com/pusher/rest/crypto/nacl/SecretBox.java
+++ b/src/main/java/com/pusher/rest/crypto/nacl/SecretBox.java
@@ -15,7 +15,8 @@ public class SecretBox {
     public static Map<String, byte[]> box(final byte[] key, final byte[] message) {
         TweetNaclFast.SecretBox secretBox = new TweetNaclFast.SecretBox(key);
 
-        final byte[] nonce = new SecureRandom().generateSeed(NONCE_LENGTH);
+        final byte[] nonce = new byte[NONCE_LENGTH];
+        new SecureRandom().nextBytes(nonce);
         final byte[] cipher = secretBox.box(message, nonce);
 
         final Map<String, byte[]> res = new HashMap<>();


### PR DESCRIPTION
Equivalent for our use case, but potentially faster in contexts where `generateSeed` would block.

Failing CI checks are unrelated and were already like that. I'll make a separate PR to address them.