### PR TITLE
Update netty dependencies to 4.17.78.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -205,6 +205,18 @@
     </plugins>
   </build>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>4.1.78.Final</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
Netty is used by `asynchttpclient` and the version that the client uses has a reported vulnerability. Unfortunately, the client doesn't seem to be maintained. This PR updates netty to a compatible version that fixes the issue.

We should look into migrating off of `asynchttpclient`.

Fixes #61.