### PR TITLE
Update Vulnerable Dependencies, Remove Deprecated Documentation Plugin, Update CI to include Java 21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java-version: [8, 11, 17]
+        java-version: [11, 17, 21]
 
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.3.4
+
+- [CHANGED] Updated org.asynchttpclient:async-http-client to 3.0.1 to address a vulnerability
+- [CHANGED] Updated CI matrix to remove Java 8 and add Java 21, reflecting current support policy
+- [CHANGED] Replaced deprecated  constructor with  in 
+- [REMOVED] Deprecated org.ajoberstar.github-pages plugin and associated configuration
+
 ## 1.3.1 2022-05-16
 
 - [CHANGED] Use SecureRandom.nextBytes instead of SecureRandom.generateSeed

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The pusher-http-java library is available in Maven Central:
 <dependency>
   <groupId>com.pusher</groupId>
   <artifactId>pusher-http-java</artifactId>
-  <version>1.3.3</version>
+  <version>1.3.4</version>
 </dependency>
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,16 +4,12 @@ buildscript {
     repositories {
         mavenCentral()
     }
-    dependencies {
-        classpath 'org.ajoberstar:gradle-git:1.1.0'
-    }
 }
 
 plugins {
     id 'java-library'
     id 'maven-publish'
     id "signing"
-    id "org.ajoberstar.github-pages" version "1.7.2"
 }
 
 def getProperty = { property ->
@@ -44,7 +40,7 @@ ext.sharedManifest = manifest {
 
 dependencies {
     implementation 'org.apache.httpcomponents:httpclient:4.5.13'
-    implementation 'org.asynchttpclient:async-http-client:2.12.3'
+    implementation 'org.asynchttpclient:async-http-client:3.0.1'
     implementation 'com.google.code.gson:gson:2.8.9'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.13'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
@@ -91,18 +87,6 @@ artifacts {
 java {
     withSourcesJar()
     withJavadocJar()
-}
-
-githubPages {
-    repoUri = 'https://github.com/pusher/pusher-http-java.git'
-    pages {
-        from javadoc.outputs.files
-    }
-    commitMessage = "JavaDoc gh-pages for ${version}"
-    credentials {
-        username = { getProperty("github.username") }
-        password = { getProperty("github.password") }
-    }
 }
 
 publishing {

--- a/build.gradle
+++ b/build.gradle
@@ -26,16 +26,12 @@ repositories {
 group = "com.pusher"
 version = "1.3.3"
 description = "Pusher HTTP Client"
-sourceCompatibility = "1.8"
-targetCompatibility = "1.8"
 
-ext.sharedManifest = manifest {
-    attributes(
-        'Created-By': 'Pusher',
-        'Implementation-Vendor': 'Pusher',
-        'Implementation-Title': 'Pusher HTTP Java',
-        'Implementation-Version': version
-    )
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+    withSourcesJar()
+    withJavadocJar()
 }
 
 dependencies {
@@ -62,31 +58,14 @@ javadoc {
 
 jar {
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-    manifest = project.manifest {
-        from sharedManifest
+    manifest {
+        attributes(
+                'Created-By': 'Pusher',
+                'Implementation-Vendor': 'Pusher',
+                'Implementation-Title': 'Pusher HTTP Java',
+                'Implementation-Version': version
+        )
     }
-}
-
-task sourcesJar(type: Jar, dependsOn: classes) {
-    archiveClassifier.set('sources')
-    from sourceSets.main.allSource
-}
-assemble.dependsOn sourcesJar
-
-
-task javadocJar(type: Jar, dependsOn: javadoc) {
-    archiveClassifier.set('javadoc')
-    from javadoc.destinationDir
-}
-assemble.dependsOn javadocJar
-
-artifacts {
-    archives jar, sourcesJar, javadocJar
-}
-
-java {
-    withSourcesJar()
-    withJavadocJar()
 }
 
 publishing {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/pusher/rest/SignatureUtil.java
+++ b/src/main/java/com/pusher/rest/SignatureUtil.java
@@ -36,7 +36,7 @@ public class SignatureUtil {
             final Map<String, String> allParams = new HashMap<String, String>(extraParams);
             allParams.put("auth_key", key);
             allParams.put("auth_version", "1.0");
-            allParams.put("auth_timestamp", new Long(System.currentTimeMillis() / 1000).toString());
+            allParams.put("auth_timestamp", Long.toString(System.currentTimeMillis() / 1000));
             if (body != null) {
                 allParams.put("body_md5", bodyMd5(body));
             }


### PR DESCRIPTION
## What does this PR do?

This PR updates the `org.asynchttpclient:async-http-client` dependency from 2.12.3 to 3.0.1, addressing a known vulnerability. In addition, it removes the deprecated `org.ajoberstar.github-pages` plugin and associated configuration from the build script. 

Also updated the CI matrix to remove Java 8 and add Java 21, aligning with our support policy to run on Java SE versions currently under Premier Support. 

We can explore a new approach (e.g., using [git-publish](https://github.com/ajoberstar/gradle-git-publish)) for automated documentation publishing in a future update. I will manually update the docs for this version. 

Refactored `SignatureUtil.java` to replace deprecated `Long(long)` constructor with `Long.toString()`.

Fixes https://github.com/pusher/pusher-http-java/issues/72

## CHANGELOG

- [CHANGED] Updated org.asynchttpclient:async-http-client to 3.0.1 to address a vulnerability
- [CHANGED] Updated CI matrix to remove Java 8 and add Java 21, reflecting current support policy
- [CHANGED] Replaced deprecated `Long(long)` constructor with `Long.toString()` in `SignatureUtil.java`
- [REMOVED] Deprecated org.ajoberstar.github-pages plugin and associated configuration
