### PR TITLE
Manually bump version for release, fix for automated release workflow

### DIFF
--- a/.github/workflows/release_pr.yml
+++ b/.github/workflows/release_pr.yml
@@ -31,6 +31,6 @@ jobs:
           perl -pi -e 's/version = "${{env.CURRENT_VERSION}}"/version = "${{steps.bump.outputs.new_version}}"/' build.gradle
           perl -pi -e 's/${{env.CURRENT_VERSION}}/${{steps.bump.outputs.new_version}}/' README.md
 
-          git add README.md CHANGELOG.md
+          git add README.md CHANGELOG.md build.gradle
           git commit -m "Bump to version ${{ steps.bump.outputs.new_version }}"
           git push

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ repositories {
 }
 
 group = "com.pusher"
-version = "1.3.3"
+version = "1.3.4"
 description = "Pusher HTTP Client"
 
 java {


### PR DESCRIPTION
## What does this PR do?

The [automated version bump commit](https://github.com/pusher/pusher-http-java/pull/73/commits/90dc3446a0e006264a0a27034663ca5fb3875798) did not commit the changes to build.gradle file, hence [the automated publishing failed](https://github.com/pusher/pusher-http-java/actions/runs/12395884593/job/34602637017#step:3:1). 

In this PR I update the version in build.gradle by hand and fix the release_pr workflow to add the build.gradle file to the commit. 


