### PR TITLE
Update artifactId and add developers section to POM

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ publishing {
             pom {
                 name = 'Pusher HTTP Client'
                 packaging = 'jar'
-                artifactId = 'pusher-java-client'
+                artifactId = 'pusher-http-java'
                 description = "This is a Java library for interacting with Pusher.com's HTTP API."
                 url = 'http://github.com/pusher/pusher-http-java'
                 scm {
@@ -99,6 +99,12 @@ publishing {
                 issueManagement {
                     system = 'GitHub'
                     url = 'https://github.com/pusher/pusher-http-java/issues'
+                }
+                developer {
+                    id = 'pusher-team'
+                    name = 'Pusher Engineering Team'
+                    organization = 'Pusher'
+                    organizationUrl = 'https://pusher.com'
                 }
             }
         }


### PR DESCRIPTION
## What does this PR do?

This PR makes the following changes to the `build.gradle` file:
- Changed the `artifactId` in the POM section from `pusher-java-client` to `pusher-http-java` to ensure consistency with the repository name and with the artifact published in Maven Central.
- Added a 'developers' section in the POM metadata to represent the Pusher Engineering Team. This is required for Maven Central. 


