### PR TITLE
Change dependencies from implementation to api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,9 +35,9 @@ java {
 }
 
 dependencies {
-    implementation 'org.apache.httpcomponents:httpclient:4.5.13'
-    implementation 'org.asynchttpclient:async-http-client:3.0.1'
-    implementation 'com.google.code.gson:gson:2.8.9'
+    api 'org.apache.httpcomponents:httpclient:4.5.13'
+    api 'org.asynchttpclient:async-http-client:3.0.1'
+    api 'com.google.code.gson:gson:2.8.9'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.13'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
     testImplementation 'org.jmock:jmock-junit5:2.12.0'


### PR DESCRIPTION
Those are not 'implementation' dependencies, because they are used in return type of public methods:

- asynchttpclient in PusherAsync.configureHttpClient
- gson in PusherAbstract.setGsonSerialiser
- httpclient in Pusher.configureHttpClient

See https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_recognizing_dependencies

> An API dependency is one that contains at least one type that is exposed in the library binary interface

## What does this PR do?

Changes dependencies in published POM from 'runtime' back to 'compile', so back to the way they were declared in https://mvnrepository.com/artifact/com.pusher/pusher-http-java/1.3.3

## CHANGELOG

- [CHANGED] Make httpclient, async-http-client and gson compile dependencies again
