### PR TITLE
chore: prepare release PR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.3.5
+
+- [CHANGED] Update async-http-client to 3.0.6.
+- [CHANGED] Change dependency scopes to api.
+- [CHANGED] Upgrade Netty to 4.1.129.Final.
+
 ## 1.3.4
 
 - [CHANGED] Updated org.asynchttpclient:async-http-client to 3.0.1 to address a vulnerability

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The pusher-http-java library is available in Maven Central:
 <dependency>
   <groupId>com.pusher</groupId>
   <artifactId>pusher-http-java</artifactId>
-  <version>1.3.4</version>
+  <version>1.3.5</version>
 </dependency>
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ repositories {
 }
 
 group = "com.pusher"
-version = "1.3.4"
+version = "1.3.5"
 description = "Pusher HTTP Client"
 
 // Netty version override to address CVE-2025-24970, CVE-2025-25193, CVE-2025-55163,


### PR DESCRIPTION
## What does this PR do?

[Description here]

## CHANGELOG

- [CHANGED] Update async-http-client to 3.0.6.
- [CHANGED] Change dependency scopes to api.
- [CHANGED] Upgrade Netty to 4.1.129.Final.
